### PR TITLE
#15 - Pinned google-api-python-client to version without breaking change

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -107,7 +107,7 @@ setup(
     author='Google Inc.',
     version=version,
     install_requires=[
-        'google-api-python-client',
+        'google-api-python-client==1.8.0',
         'google-auth>=1.0.0',
         'google-auth-httplib2',
         'pyyaml',


### PR DESCRIPTION
See issue #15 . An upstream change in `google-api-python-client` where `__version__` was removed causing this library to break. This pins the version to before that change until a fix can be made. 