### PR TITLE
Added support load source-context.json from pwd

### DIFF
--- a/src/googleclouddebugger/gcp_hub_client.py
+++ b/src/googleclouddebugger/gcp_hub_client.py
@@ -551,8 +551,10 @@ class GcpHubClient(object):
       Parsed JSON data or None if the file does not exist, can't be read or
       not a valid JSON file.
     """
-    try:
-      with open(os.path.join(sys.path[0], relative_path), 'r') as f:
-        return json.load(f)
-    except (IOError, ValueError):
-      return None
+    for path in (sys.path[0], os.getcwd()):
+      try:
+        with open(os.path.join(path, relative_path), 'r') as f:
+          return json.load(f)
+      except (IOError, ValueError):
+        pass
+    return None


### PR DESCRIPTION
Useful when using entry_point in setup.py

Because in this case, `sys.path[0]` contains the path to virtualenv