### PR TITLE
Fix example Dockerfile not building with latest version of alpine

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -14,8 +14,7 @@ ENV PYTHON_VERSION=$PYTHON_VERSION
 ENV PYTHON=python${PYTHON_VERSION}
 
 RUN apk update
-RUN apk add bash git curl gcc g++ make cmake ${PYTHON}-dev
-RUN if [ $PYTHON_VERSION == "2" ]; then apk add py-setuptools; fi
+RUN apk add bash git curl gcc g++ make cmake ${PYTHON}-dev py${PYTHON_VERSION}-setuptools
 
 RUN git clone https://github.com/GoogleCloudPlatform/cloud-debug-python
 RUN PYTHON=$PYTHON bash cloud-debug-python/src/build.sh
@@ -29,7 +28,12 @@ ENV PYTHON_VERSION=$PYTHON_VERSION
 ENV PYTHON=python${PYTHON_VERSION}
 
 RUN apk --no-cache add $PYTHON libstdc++
-RUN if [ $PYTHON_VERSION == "2" ]; then apk add --no-cache py-setuptools; fi
+RUN if [ $PYTHON_VERSION == "2" ]; \
+    then apk add --no-cache py${PYTHON_VERSION}-setuptools; fi
+# Install setuptools with easy_install. Newer versions don't include easy_install.
+# https://setuptools.pypa.io/en/latest/history.html?highlight=easy_install#id88
+RUN if [ $PYTHON_VERSION == "3" ]; \
+    then apk add --no-cache py${PYTHON_VERSION}-pip; pip install --no-cache-dir setuptools==51.3.3; fi
 
 COPY --from=0 /cloud-debug-python/src/dist/*.egg .
 RUN $PYTHON -m easy_install *.egg


### PR DESCRIPTION
Easy install is deprecated in version 42 or newer: https://setuptools.pypa.io/en/latest/history.html?highlight=easy_install#id303
Since pip doesn't support egg files, the "cloud-debug-python/src/build.sh" script will have to generate a whl file to support newer versions.