### PR TITLE
chore: bump gflags and glog to newer versions

### DIFF
--- a/src/build-wheels.sh
+++ b/src/build-wheels.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
-GFLAGS_URL=https://github.com/gflags/gflags/archive/v2.1.2.tar.gz
-GLOG_URL=https://github.com/google/glog/archive/v0.3.4.tar.gz
+GFLAGS_URL=https://github.com/gflags/gflags/archive/v2.2.2.tar.gz
+GLOG_URL=https://github.com/google/glog/archive/v0.4.0.tar.gz
 
 SUPPORTED_VERSIONS=(cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39)
 
@@ -36,9 +36,12 @@ pushd ${ROOT}/build/third_party
 curl -L ${GLOG_URL} -o glog.tar.gz
 tar xzvf glog.tar.gz
 cd glog-*
-./configure --with-pic \
-            --prefix=${ROOT}/build/third_party \
-            --with-gflags=${ROOT}/build/third_party
+mkdir build
+cd build
+cmake -DCMAKE_CXX_FLAGS=-fpic \
+      -DCMAKE_PREFIX_PATH=${ROOT}/build/third_party \
+      -DCMAKE_INSTALL_PREFIX:PATH=${ROOT}/build/third_party \
+      ..
 make ${PARALLEL_BUILD_OPTION}
 make install
 popd
@@ -54,7 +57,7 @@ verbose=1
 
 [build_ext]
 include_dirs=${ROOT}/build/third_party/include
-library_dirs=${ROOT}/build/third_party/lib" > ${ROOT}/setup.cfg
+library_dirs=${ROOT}/build/third_party/lib:${ROOT}/build/third_party/lib64" > ${ROOT}/setup.cfg
 
 # Build the Python Cloud Debugger agent.
 pushd ${ROOT}

--- a/src/build.sh
+++ b/src/build.sh
@@ -33,8 +33,8 @@
 # Home page of glog: https://github.com/google/glog
 #
 
-GFLAGS_URL=https://github.com/gflags/gflags/archive/v2.1.2.tar.gz
-GLOG_URL=https://github.com/google/glog/archive/v0.3.4.tar.gz
+GFLAGS_URL=https://github.com/gflags/gflags/archive/v2.2.2.tar.gz
+GLOG_URL=https://github.com/google/glog/archive/v0.4.0.tar.gz
 
 ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") >/dev/null; /bin/pwd -P)
 
@@ -67,9 +67,12 @@ pushd ${ROOT}/build/third_party
 curl -L ${GLOG_URL} -o glog.tar.gz
 tar xzvf glog.tar.gz
 cd glog-*
-./configure --with-pic \
-            --prefix=${ROOT}/build/third_party \
-            --with-gflags=${ROOT}/build/third_party
+mkdir build
+cd build
+cmake -DCMAKE_CXX_FLAGS=-fpic \
+      -DCMAKE_PREFIX_PATH=${ROOT}/build/third_party \
+      -DCMAKE_INSTALL_PREFIX:PATH=${ROOT}/build/third_party \
+      ..
 make ${PARALLEL_BUILD_OPTION}
 make install
 popd
@@ -80,7 +83,7 @@ verbose=1
 
 [build_ext]
 include_dirs=${ROOT}/build/third_party/include
-library_dirs=${ROOT}/build/third_party/lib" > ${ROOT}/setup.cfg
+library_dirs=${ROOT}/build/third_party/lib:${ROOT}/build/third_party/lib64" > ${ROOT}/setup.cfg
 
 # Build the Python Cloud Debugger agent.
 pushd ${ROOT}


### PR DESCRIPTION
glog in particular was starting to run into issues due to its age.

v0.4.0 was chosen because it strikes the balance of being newer while still producing libglog.a for static linking.