### PR TITLE
chore: add pylint and yapf

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,429 @@
+# This Pylint rcfile contains a best-effort configuration to uphold the
+# best-practices and style described in the Google Python style guide:
+#   https://google.github.io/styleguide/pyguide.html
+#
+# Its canonical open-source location is:
+#   https://google.github.io/styleguide/pylintrc
+
+[MASTER]
+
+# Files or directories to be skipped. They should be base names, not paths.
+ignore=third_party
+
+# Files or directories matching the regex patterns are skipped. The regex
+# matches against base names, not paths.
+ignore-patterns=
+
+# Pickle collected data for later comparisons.
+persistent=no
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Use multiple processes to speed up Pylint.
+jobs=4
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+#enable=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+disable=abstract-method,
+        apply-builtin,
+        arguments-differ,
+        attribute-defined-outside-init,
+        backtick,
+        bad-option-value,
+        basestring-builtin,
+        buffer-builtin,
+        c-extension-no-member,
+        consider-using-enumerate,
+        cmp-builtin,
+        cmp-method,
+        coerce-builtin,
+        coerce-method,
+        delslice-method,
+        div-method,
+        duplicate-code,
+        eq-without-hash,
+        execfile-builtin,
+        file-builtin,
+        filter-builtin-not-iterating,
+        fixme,
+        getslice-method,
+        global-statement,
+        hex-method,
+        idiv-method,
+        implicit-str-concat,
+        import-error,
+        import-self,
+        import-star-module-level,
+        inconsistent-return-statements,
+        input-builtin,
+        intern-builtin,
+        invalid-str-codec,
+        locally-disabled,
+        long-builtin,
+        long-suffix,
+        map-builtin-not-iterating,
+        misplaced-comparison-constant,
+        missing-function-docstring,
+        metaclass-assignment,
+        next-method-called,
+        next-method-defined,
+        no-absolute-import,
+        no-else-break,
+        no-else-continue,
+        no-else-raise,
+        no-else-return,
+        no-init,  # added
+        no-member,
+        no-name-in-module,
+        no-self-use,
+        nonzero-method,
+        oct-method,
+        old-division,
+        old-ne-operator,
+        old-octal-literal,
+        old-raise-syntax,
+        parameter-unpacking,
+        print-statement,
+        raising-string,
+        range-builtin-not-iterating,
+        raw_input-builtin,
+        rdiv-method,
+        reduce-builtin,
+        relative-import,
+        reload-builtin,
+        round-builtin,
+        setslice-method,
+        signature-differs,
+        standarderror-builtin,
+        suppressed-message,
+        sys-max-int,
+        too-few-public-methods,
+        too-many-ancestors,
+        too-many-arguments,
+        too-many-boolean-expressions,
+        too-many-branches,
+        too-many-instance-attributes,
+        too-many-locals,
+        too-many-nested-blocks,
+        too-many-public-methods,
+        too-many-return-statements,
+        too-many-statements,
+        trailing-newlines,
+        unichr-builtin,
+        unicode-builtin,
+        unnecessary-pass,
+        unpacking-in-except,
+        useless-else-on-loop,
+        useless-object-inheritance,
+        useless-suppression,
+        using-cmp-argument,
+        wrong-import-order,
+        xrange-builtin,
+        zip-builtin-not-iterating,
+
+
+[REPORTS]
+
+# Set the output format. Available formats are text, parseable, colorized, msvs
+# (visual studio) and html. You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages
+reports=no
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+#msg-template=
+
+
+[BASIC]
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=main,_
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+property-classes=abc.abstractproperty,cached_property.cached_property,cached_property.threaded_cached_property,cached_property.cached_property_with_ttl,cached_property.threaded_cached_property_with_ttl
+
+# Regular expression matching correct function names
+function-rgx=^(?:(?P<exempt>setUp|tearDown|setUpModule|tearDownModule)|(?P<camel_case>_?[A-Z][a-zA-Z0-9]*)|(?P<snake_case>_?[a-z][a-z0-9_]*))$
+
+# Regular expression matching correct variable names
+variable-rgx=^[a-z][a-z0-9_]*$
+
+# Regular expression matching correct constant names
+const-rgx=^(_?[A-Z][A-Z0-9_]*|__[a-z0-9_]+__|_?[a-z][a-z0-9_]*)$
+
+# Regular expression matching correct attribute names
+attr-rgx=^_{0,2}[a-z][a-z0-9_]*$
+
+# Regular expression matching correct argument names
+argument-rgx=^[a-z][a-z0-9_]*$
+
+# Regular expression matching correct class attribute names
+class-attribute-rgx=^(_?[A-Z][A-Z0-9_]*|__[a-z0-9_]+__|_?[a-z][a-z0-9_]*)$
+
+# Regular expression matching correct inline iteration names
+inlinevar-rgx=^[a-z][a-z0-9_]*$
+
+# Regular expression matching correct class names
+class-rgx=^_?[A-Z][a-zA-Z0-9]*$
+
+# Regular expression matching correct module names
+module-rgx=^(_?[a-z][a-z0-9_]*|__init__)$
+
+# Regular expression matching correct method names
+method-rgx=(?x)^(?:(?P<exempt>_[a-z0-9_]+__|runTest|setUp|tearDown|setUpTestCase|tearDownTestCase|setupSelf|tearDownClass|setUpClass|(test|assert)_*[A-Z0-9][a-zA-Z0-9_]*|next)|(?P<camel_case>_{0,2}[A-Z][a-zA-Z0-9_]*)|(?P<snake_case>_{0,2}[a-z][a-z0-9_]*))$
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=(__.*__|main|test.*|.*test|.*Test)$
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=10
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager,contextlib2.contextmanager
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+
+[FORMAT]
+
+# Maximum number of characters on a single line.
+max-line-length=80
+
+# TODO(https://github.com/PyCQA/pylint/issues/3352): Direct pylint to exempt
+# lines made too long by directives to pytype.
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=(?x)(
+  ^\s*(\#\ )?<?https?://\S+>?$|
+  ^\s*(from\s+\S+\s+)?import\s+.+$)
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=yes
+
+# Maximum number of lines in a module
+max-module-lines=99999
+
+# String used as indentation unit.  The internal Google style guide mandates 2
+# spaces.  Google's externaly-published style guide says 4, consistent with
+# PEP 8.  Here, we use 2 spaces, for conformity with many open-sourced Google
+# projects (like TensorFlow).
+indent-string='  '
+
+# Number of spaces of indent required inside a hanging  or continued line.
+indent-after-paren=4
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=TODO
+
+
+[STRING]
+
+# This flag controls whether inconsistent-quotes generates a warning when the
+# character used as a quote delimiter is used inconsistently within a module.
+check-quote-consistency=yes
+
+
+[VARIABLES]
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=^\*{0,2}(_$|unused_|dummy_)
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,_cb
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six,six.moves,past.builtins,future.builtins,functools
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging,absl.logging,tensorflow.io.logging
+
+
+[SIMILARITIES]
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+
+[SPELLING]
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[IMPORTS]
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=regsub,
+                   TERMIOS,
+                   Bastion,
+                   rexec,
+                   sets
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant, absl
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls,
+                            class_
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=StandardError,
+                       Exception,
+                       BaseException

--- a/.style.yapf
+++ b/.style.yapf
@@ -1,0 +1,2 @@
+[style]
+based_on_style = yapf

--- a/src/googleclouddebugger/__init__.py
+++ b/src/googleclouddebugger/__init__.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Main module for Python Cloud Debugger.
 
 The debugger is enabled in a very similar way to enabling pdb.
@@ -56,8 +55,7 @@ def _StartDebugger():
   visibility_policy = _GetVisibilityPolicy()
 
   _breakpoints_manager = breakpoints_manager.BreakpointsManager(
-      _hub_client,
-      visibility_policy)
+      _hub_client, visibility_policy)
 
   # Set up loggers for logpoints.
   capture_collector.SetLogger(logging.getLogger())
@@ -69,8 +67,7 @@ def _StartDebugger():
       _breakpoints_manager.SetActiveBreakpoints)
   _hub_client.on_idle = _breakpoints_manager.CheckBreakpointsExpiration
   _hub_client.SetupAuth(
-      _flags.get('project_id'),
-      _flags.get('project_number'),
+      _flags.get('project_id'), _flags.get('project_number'),
       _flags.get('service_account_json_file'))
   _hub_client.SetupCanaryMode(
       _flags.get('breakpoint_enable_canary'),
@@ -123,9 +120,11 @@ def _DebuggerMain():
 
   import __main__  # pylint: disable=g-import-not-at-top
   __main__.__dict__.clear()
-  __main__.__dict__.update({'__name__': '__main__',
-                            '__file__': app_path,
-                            '__builtins__': __builtins__})
+  __main__.__dict__.update({
+      '__name__': '__main__',
+      '__file__': app_path,
+      '__builtins__': __builtins__
+  })
   locals = globals = __main__.__dict__  # pylint: disable=redefined-builtin
 
   sys.modules['__main__'] = __main__

--- a/src/googleclouddebugger/__init__.py
+++ b/src/googleclouddebugger/__init__.py
@@ -48,8 +48,8 @@ def _StartDebugger():
   global _breakpoints_manager
 
   cdbg_native.InitializeModule(_flags)
-  cdbg_native.LogInfo('Initializing Cloud Debugger Python agent version: %s' %
-                      __version__)
+  cdbg_native.LogInfo(
+      f'Initializing Cloud Debugger Python agent version: {__version__}')
 
   _hub_client = gcp_hub_client.GcpHubClient()
   visibility_policy = _GetVisibilityPolicy()
@@ -82,7 +82,7 @@ def _GetVisibilityPolicy():
     visibility_config = yaml_data_visibility_config_reader.OpenAndRead()
   except yaml_data_visibility_config_reader.Error as err:
     return error_data_visibility_policy.ErrorDataVisibilityPolicy(
-        'Could not process debugger config: %s' % err)
+        f'Could not process debugger config: {err}')
 
   if visibility_config:
     return glob_data_visibility_policy.GlobDataVisibilityPolicy(
@@ -118,7 +118,7 @@ def _DebuggerMain():
 
   sys.path[0] = os.path.dirname(app_path)
 
-  import __main__  # pylint: disable=g-import-not-at-top
+  import __main__  # pylint: disable=import-outside-toplevel
   __main__.__dict__.clear()
   __main__.__dict__.update({
       '__name__': '__main__',
@@ -129,7 +129,7 @@ def _DebuggerMain():
 
   sys.modules['__main__'] = __main__
 
-  with open(app_path) as f:
+  with open(app_path, encoding='utf-8') as f:
     code = compile(f.read(), app_path, 'exec')
     exec(code, globals, locals)  # pylint: disable=exec-used
 

--- a/src/googleclouddebugger/__main__.py
+++ b/src/googleclouddebugger/__main__.py
@@ -11,10 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Entry point for Python Cloud Debugger."""  # pylint: disable=invalid-name
 
 if __name__ == '__main__':
   import googleclouddebugger
   googleclouddebugger._DebuggerMain()
-

--- a/src/googleclouddebugger/appengine_pretty_printers.py
+++ b/src/googleclouddebugger/appengine_pretty_printers.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Formatters for well known objects that don't show up nicely by default."""
 
 import six

--- a/src/googleclouddebugger/application_info.py
+++ b/src/googleclouddebugger/application_info.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Module to fetch information regarding the current application.
 
 Some examples of the information the methods in this module fetch are platform
@@ -65,8 +64,8 @@ def GetRegion():
 
   # Otherwise try fetching it from the metadata server.
   try:
-    response = requests.get(_GCP_METADATA_REGION_URL,
-                            headers=_GCP_METADATA_HEADER)
+    response = requests.get(
+        _GCP_METADATA_REGION_URL, headers=_GCP_METADATA_HEADER)
     response.raise_for_status()
     # Example of response text: projects/id/regions/us-central1. So we strip
     # everything before the last /.

--- a/src/googleclouddebugger/backoff.py
+++ b/src/googleclouddebugger/backoff.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Implements exponential backoff for retry timeouts."""
 
 

--- a/src/googleclouddebugger/breakpoints_manager.py
+++ b/src/googleclouddebugger/breakpoints_manager.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Manages lifetime of individual breakpoint objects."""
 
 from datetime import datetime
@@ -40,9 +39,7 @@ class BreakpointsManager(object):
         of a captured variable.  May be None if no policy is available.
   """
 
-  def __init__(self,
-               hub_client,
-               data_visibility_policy):
+  def __init__(self, hub_client, data_visibility_policy):
     self._hub_client = hub_client
     self.data_visibility_policy = data_visibility_policy
 
@@ -78,13 +75,11 @@ class BreakpointsManager(object):
       # Create new breakpoints.
       self._active.update([
           (x['id'],
-           python_breakpoint.PythonBreakpoint(
-               x,
-               self._hub_client,
-               self,
-               self.data_visibility_policy))
+           python_breakpoint.PythonBreakpoint(x, self._hub_client, self,
+                                              self.data_visibility_policy))
           for x in breakpoints_data
-          if x['id'] in ids - six.viewkeys(self._active) - self._completed])
+          if x['id'] in ids - six.viewkeys(self._active) - self._completed
+      ])
 
       # Remove entries from completed_breakpoints_ that weren't listed in
       # breakpoints_data vector. These are confirmed to have been removed by the

--- a/src/googleclouddebugger/capture_collector.py
+++ b/src/googleclouddebugger/capture_collector.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Captures application state on a breakpoint hit."""
 
 # TODO: rename this file to collector.py.
@@ -280,8 +279,8 @@ class CaptureCollector(object):
     # because in the case where the user has not indicated a preference, we
     # don't want a single large object on the stack to use the entire max_size
     # quota and hide the rest of the data.
-    self.expression_capture_limits = _CaptureLimits(max_value_len=32768,
-                                                    max_list_items=32768)
+    self.expression_capture_limits = _CaptureLimits(
+        max_value_len=32768, max_list_items=32768)
 
   def Collect(self, top_frame):
     """Collects call stack, local variables and objects.
@@ -301,8 +300,9 @@ class CaptureCollector(object):
       # Evaluate watched expressions.
       if 'expressions' in self.breakpoint:
         self.breakpoint['evaluatedExpressions'] = [
-            self._CaptureExpression(top_frame, expression) for expression
-            in self.breakpoint['expressions']]
+            self._CaptureExpression(top_frame, expression)
+            for expression in self.breakpoint['expressions']
+        ]
 
       while frame and (len(breakpoint_frames) < self.max_frames):
         line = top_line if frame == top_frame else frame.f_lineno
@@ -332,7 +332,10 @@ class CaptureCollector(object):
           'description': {
               'format': ('INTERNAL ERROR: Failed while capturing locals '
                          'of frame $0: $1'),
-              'parameters': [str(len(breakpoint_frames)), str(e)]}}
+              'parameters': [str(len(breakpoint_frames)),
+                             str(e)]
+          }
+      }
 
     # Number of entries in _var_table. Starts at 1 (index 0 is the 'buffer full'
     # status value).
@@ -340,10 +343,12 @@ class CaptureCollector(object):
 
     # Explore variables table in BFS fashion. The variables table will grow
     # inside CaptureVariable as we encounter new references.
-    while (num_vars < len(self._var_table)) and (
-        self._total_size < self.max_size):
+    while (num_vars < len(self._var_table)) and (self._total_size <
+                                                 self.max_size):
       self._var_table[num_vars] = self.CaptureVariable(
-          self._var_table[num_vars], 0, self.default_capture_limits,
+          self._var_table[num_vars],
+          0,
+          self.default_capture_limits,
           can_enqueue=False)
 
       # Move on to the next entry in the variable table.
@@ -367,18 +372,22 @@ class CaptureCollector(object):
       (arguments, locals) tuple.
     """
     # Capture all local variables (including method arguments).
-    variables = {n: self.CaptureNamedVariable(n, v, 1,
-                                              self.default_capture_limits)
-                 for n, v in six.viewitems(frame.f_locals)}
+    variables = {
+        n: self.CaptureNamedVariable(n, v, 1, self.default_capture_limits)
+        for n, v in six.viewitems(frame.f_locals)
+    }
 
     # Split between locals and arguments (keeping arguments in the right order).
     nargs = frame.f_code.co_argcount
-    if frame.f_code.co_flags & inspect.CO_VARARGS: nargs += 1
-    if frame.f_code.co_flags & inspect.CO_VARKEYWORDS: nargs += 1
+    if frame.f_code.co_flags & inspect.CO_VARARGS:
+      nargs += 1
+    if frame.f_code.co_flags & inspect.CO_VARKEYWORDS:
+      nargs += 1
 
     frame_arguments = []
     for argname in frame.f_code.co_varnames[:nargs]:
-      if argname in variables: frame_arguments.append(variables.pop(argname))
+      if argname in variables:
+        frame_arguments.append(variables.pop(argname))
 
     return (frame_arguments, list(six.viewvalues(variables)))
 
@@ -400,8 +409,9 @@ class CaptureCollector(object):
       name = str(id(name))
     self._total_size += len(name)
 
-    v = (self.CheckDataVisibility(value) or
-         self.CaptureVariable(value, depth, limits))
+    v = (
+        self.CheckDataVisibility(value) or
+        self.CaptureVariable(value, depth, limits))
     v['name'] = name
     return v
 
@@ -449,23 +459,30 @@ class CaptureCollector(object):
     """
     v = []
     for name, value in items:
-      if (self._total_size >= self.max_size) or (
-          len(v) >= limits.max_list_items):
+      if (self._total_size >= self.max_size) or (len(v) >=
+                                                 limits.max_list_items):
         v.append({
             'status': {
                 'refersTo': 'VARIABLE_VALUE',
                 'description': {
-                    'format':
-                        ('Only first $0 items were captured. Use in an '
-                         'expression to see all items.'),
-                    'parameters': [str(len(v))]}}})
+                    'format': ('Only first $0 items were captured. Use in an '
+                               'expression to see all items.'),
+                    'parameters': [str(len(v))]
+                }
+            }
+        })
         break
       v.append(self.CaptureNamedVariable(name, value, depth, limits))
 
     if not v:
-      return [{'status': {
-          'refersTo': 'VARIABLE_NAME',
-          'description': {'format': empty_message}}}]
+      return [{
+          'status': {
+              'refersTo': 'VARIABLE_NAME',
+              'description': {
+                  'format': empty_message
+              }
+          }
+      }]
 
     return v
 
@@ -508,31 +525,34 @@ class CaptureCollector(object):
       return {'value': 'None'}
 
     if isinstance(value, _PRIMITIVE_TYPES):
-      r = _TrimString(repr(value),  # Primitive type, always immutable.
-                      min(limits.max_value_len,
-                          self.max_size - self._total_size))
+      r = _TrimString(
+          repr(value),  # Primitive type, always immutable.
+          min(limits.max_value_len, self.max_size - self._total_size))
       self._total_size += len(r)
       return {'value': r, 'type': type(value).__name__}
 
     if isinstance(value, _DATE_TYPES):
       r = str(value)  # Safe to call str().
       self._total_size += len(r)
-      return {'value': r, 'type': 'datetime.'+ type(value).__name__}
+      return {'value': r, 'type': 'datetime.' + type(value).__name__}
 
     if isinstance(value, dict):
       # Do not use iteritems() here. If GC happens during iteration (which it
       # often can for dictionaries containing large variables), you will get a
       # RunTimeError exception.
       items = [(repr(k), v) for (k, v) in value.items()]
-      return {'members':
-              self.CaptureVariablesList(items, depth + 1,
-                                        EMPTY_DICTIONARY, limits),
-              'type': 'dict'}
+      return {
+          'members':
+              self.CaptureVariablesList(items, depth + 1, EMPTY_DICTIONARY,
+                                        limits),
+          'type':
+              'dict'
+      }
 
     if isinstance(value, _VECTOR_TYPES):
       fields = self.CaptureVariablesList(
-          (('[%d]' % i, x) for i, x in enumerate(value)),
-          depth + 1, EMPTY_COLLECTION, limits)
+          (('[%d]' % i, x) for i, x in enumerate(value)), depth + 1,
+          EMPTY_COLLECTION, limits)
       return {'members': fields, 'type': type(value).__name__}
 
     if isinstance(value, types.FunctionType):
@@ -542,8 +562,8 @@ class CaptureCollector(object):
 
     if isinstance(value, Exception):
       fields = self.CaptureVariablesList(
-          (('[%d]' % i, x) for i, x in enumerate(value.args)),
-          depth + 1, EMPTY_COLLECTION, limits)
+          (('[%d]' % i, x) for i, x in enumerate(value.args)), depth + 1,
+          EMPTY_COLLECTION, limits)
       return {'members': fields, 'type': type(value).__name__}
 
     if can_enqueue:
@@ -561,10 +581,13 @@ class CaptureCollector(object):
         continue
 
       fields, object_type = pretty_value
-      return {'members':
+      return {
+          'members':
               self.CaptureVariablesList(fields, depth + 1, OBJECT_HAS_NO_FIELDS,
                                         limits),
-              'type': object_type}
+          'type':
+              object_type
+      }
 
     if not hasattr(value, '__dict__'):
       # TODO: keep "value" empty and populate the "type" field instead.
@@ -580,8 +603,8 @@ class CaptureCollector(object):
       # Only limits.max_list_items + 1 items are copied, anything past that will
       # get ignored by CaptureVariablesList().
       items = list(itertools.islice(items, limits.max_list_items + 1))
-    members = self.CaptureVariablesList(items, depth + 2,
-                                        OBJECT_HAS_NO_FIELDS, limits)
+    members = self.CaptureVariablesList(items, depth + 2, OBJECT_HAS_NO_FIELDS,
+                                        limits)
     v = {'members': members}
 
     type_string = DetermineType(value)
@@ -736,8 +759,12 @@ class LogCollector(object):
     """
     # Return error if log methods were not configured globally.
     if not self._log_message:
-      return {'isError': True,
-              'description': {'format': LOG_ACTION_NOT_SUPPORTED}}
+      return {
+          'isError': True,
+          'description': {
+              'format': LOG_ACTION_NOT_SUPPORTED
+          }
+      }
 
     if self._quota_recovery_start_time:
       ms_elapsed = (time.time() - self._quota_recovery_start_time) * 1000
@@ -778,8 +805,10 @@ class LogCollector(object):
       Array of strings where each string corresponds to the breakpoint
       expression with the same index.
     """
-    return [self._FormatExpression(frame, expression) for expression in
-            self._definition.get('expressions') or []]
+    return [
+        self._FormatExpression(frame, expression)
+        for expression in self._definition.get('expressions') or []
+    ]
 
   def _FormatExpression(self, frame, expression):
     """Evaluates a single watched expression and formats it into a string form.
@@ -819,8 +848,7 @@ class LogCollector(object):
     def FormatDictItem(key_value):
       """Formats single dictionary item."""
       key, value = key_value
-      return (self._FormatValue(key, level + 1) +
-              ': ' +
+      return (self._FormatValue(key, level + 1) + ': ' +
               self._FormatValue(value, level + 1))
 
     def LimitedEnumerate(items, formatter, level=0):
@@ -840,8 +868,9 @@ class LogCollector(object):
       return ', '.join(LimitedEnumerate(items, formatter, level=level))
 
     if isinstance(value, _PRIMITIVE_TYPES):
-      return _TrimString(repr(value),  # Primitive type, always immutable.
-                         self.max_value_len)
+      return _TrimString(
+          repr(value),  # Primitive type, always immutable.
+          self.max_value_len)
 
     if isinstance(value, _DATE_TYPES):
       return str(value)
@@ -853,8 +882,11 @@ class LogCollector(object):
       return '{' + FormatList(six.iteritems(value), FormatDictItem) + '}'
 
     if isinstance(value, _VECTOR_TYPES):
-      return _ListTypeFormatString(value).format(FormatList(
-          value, lambda item: self._FormatValue(item, level + 1), level=level))
+      return _ListTypeFormatString(value).format(
+          FormatList(
+              value,
+              lambda item: self._FormatValue(item, level + 1),
+              level=level))
 
     if isinstance(value, types.FunctionType):
       return 'function ' + value.__name__
@@ -884,14 +916,18 @@ def _EvaluateExpression(frame, expression):
         'refersTo': 'VARIABLE_NAME',
         'description': {
             'format': 'Invalid expression',
-            'parameters': [str(e)]}})
+            'parameters': [str(e)]
+        }
+    })
   except SyntaxError as e:
     return (False, {
         'isError': True,
         'refersTo': 'VARIABLE_NAME',
         'description': {
             'format': 'Expression could not be compiled: $0',
-            'parameters': [e.msg]}})
+            'parameters': [e.msg]
+        }
+    })
 
   try:
     return (True, native.CallImmutable(frame, code))
@@ -901,7 +937,9 @@ def _EvaluateExpression(frame, expression):
         'refersTo': 'VARIABLE_VALUE',
         'description': {
             'format': 'Exception occurred: $0',
-            'parameters': [str(e)]}})
+            'parameters': [str(e)]
+        }
+    })
 
 
 def _GetFrameCodeObjectName(frame):
@@ -917,8 +955,8 @@ def _GetFrameCodeObjectName(frame):
   # This functions under the assumption that member functions will name their
   # first parameter argument 'self' but has some edge-cases.
   if frame.f_code.co_argcount >= 1 and 'self' == frame.f_code.co_varnames[0]:
-    return (frame.f_locals['self'].__class__.__name__ +
-            '.' + frame.f_code.co_name)
+    return (frame.f_locals['self'].__class__.__name__ + '.' +
+            frame.f_code.co_name)
   else:
     return frame.f_code.co_name
 
@@ -933,6 +971,7 @@ def _FormatMessage(template, parameters):
   Returns:
     Formatted message with parameters embedded in template placeholders.
   """
+
   def GetParameter(m):
     try:
       return parameters[int(m.group(0)[1:])]
@@ -947,4 +986,4 @@ def _TrimString(s, max_len):
   """Trims the string if it exceeds max_len."""
   if len(s) <= max_len:
     return s
-  return s[:max_len+1] + '...'
+  return s[:max_len + 1] + '...'

--- a/src/googleclouddebugger/error_data_visibility_policy.py
+++ b/src/googleclouddebugger/error_data_visibility_policy.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Always returns the provided error on visibility requests.
 
 Example Usage:

--- a/src/googleclouddebugger/gcp_hub_client.py
+++ b/src/googleclouddebugger/gcp_hub_client.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Communicates with Cloud Debugger backend over HTTP."""
 
 from collections import deque
@@ -27,8 +26,6 @@ import sys
 import threading
 import time
 import traceback
-
-
 
 import google_auth_httplib2
 import googleapiclient
@@ -143,6 +140,7 @@ class GcpHubClient(object):
           if os.path.splitext(f[1])[0] == self._my_filename:
             return False
         return True
+
     self._log_filter = _ChildLogFilter({logging.INFO})
     googleapiclient.discovery.logger.addFilter(self._log_filter)
 
@@ -196,9 +194,11 @@ class GcpHubClient(object):
       self._debuggee_labels[labels.Debuggee.VERSION] = 'unversioned'
 
     if flags:
-      self._debuggee_labels.update(
-          {name: value for (name, value) in six.iteritems(flags)
-           if name in _DEBUGGEE_LABELS})
+      self._debuggee_labels.update({
+          name: value
+          for (name, value) in six.iteritems(flags)
+          if name in _DEBUGGEE_LABELS
+      })
 
     self._debuggee_labels[labels.Debuggee.PROJECT_ID] = self._project_id
 
@@ -414,9 +414,8 @@ class GcpHubClient(object):
         breakpoints = response.get('breakpoints') or []
         if self._breakpoints != breakpoints:
           self._breakpoints = breakpoints
-          native.LogInfo(
-              'Breakpoints list changed, %d active, wait token: %s' % (
-                  len(self._breakpoints), self._wait_token))
+          native.LogInfo('Breakpoints list changed, %d active, wait token: %s' %
+                         (len(self._breakpoints), self._wait_token))
           self.on_active_breakpoints_changed(copy.deepcopy(self._breakpoints))
     except BaseException:
       native.LogInfo('Failed to query active breakpoints: ' +
@@ -461,11 +460,14 @@ class GcpHubClient(object):
 
       try:
         service.debuggees().breakpoints().update(
-            debuggeeId=self._debuggee_id, id=breakpoint['id'],
-            body={'breakpoint': breakpoint}).execute()
+            debuggeeId=self._debuggee_id,
+            id=breakpoint['id'],
+            body={
+                'breakpoint': breakpoint
+            }).execute()
 
-        native.LogInfo('Breakpoint %s update transmitted successfully' % (
-            breakpoint['id']))
+        native.LogInfo('Breakpoint %s update transmitted successfully' %
+                       (breakpoint['id']))
       except googleapiclient.errors.HttpError as err:
         # Treat 400 error codes (except timeout) as application error that will
         # not be retried. All other errors are assumed to be transient.
@@ -495,9 +497,8 @@ class GcpHubClient(object):
           # Socket errors shouldn't persist like this; reconnect.
           reconnect = True
       except BaseException:
-        native.LogWarning(
-            'Fatal error sending breakpoint %s update: %s' % (
-                breakpoint['id'], traceback.format_exc()))
+        native.LogWarning('Fatal error sending breakpoint %s update: %s' %
+                          (breakpoint['id'], traceback.format_exc()))
         reconnect = True
 
     self._transmission_queue.extend(retry_list)
@@ -513,8 +514,8 @@ class GcpHubClient(object):
     """Builds the debuggee structure."""
     major_version = 'v' + version.__version__.split('.')[0]
     python_version = ''.join(platform.python_version().split('.')[:2])
-    agent_version = ('google.com/python%s-gcp/%s' % (python_version,
-                                                     major_version))
+    agent_version = ('google.com/python%s-gcp/%s' %
+                     (python_version, major_version))
 
     debuggee = {
         'project': self._project_number,

--- a/src/googleclouddebugger/glob_data_visibility_policy.py
+++ b/src/googleclouddebugger/glob_data_visibility_policy.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Determines the visibility of python data and symbols.
 
 Example Usage:
@@ -32,7 +31,6 @@ Example Usage:
 """
 
 import fnmatch
-
 
 # Possible visibility responses
 RESPONSES = {
@@ -86,4 +84,3 @@ def _Matches(path, pattern_list):
   """
   # Note: This code does not scale to large pattern_list sizes.
   return any(fnmatch.fnmatchcase(path, pattern) for pattern in pattern_list)
-

--- a/src/googleclouddebugger/imphook2.py
+++ b/src/googleclouddebugger/imphook2.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Support for breakpoints on modules that haven't been loaded yet.
 
 This is the new module import hook which:
@@ -168,8 +167,11 @@ def _ProcessImportBySuffix(name, fromlist, globals):
 
 
 # pylint: disable=redefined-builtin, g-doc-args, g-doc-return-or-yield
-def _ImportHookBySuffix(
-    name, globals=None, locals=None, fromlist=None, level=None):
+def _ImportHookBySuffix(name,
+                        globals=None,
+                        locals=None,
+                        fromlist=None,
+                        level=None):
   """Callback when an import statement is executed by the Python interpreter.
 
   Argument names have to exactly match those of __import__. Otherwise calls
@@ -272,6 +274,7 @@ def _GenerateNames(name, fromlist, globals):
     the execution of this import statement.
     The returned set may contain names that are not real modules.
   """
+
   def GetCurrentPackage(globals):
     """Finds the name of the package for the currently executing module."""
     if not globals:
@@ -375,6 +378,7 @@ def _InvokeImportCallbackBySuffix(names):
            to a module. The list is expected to be much smaller than the exact
            sys.modules so that a linear search is not as costly.
   """
+
   def GetModuleFromName(name, path):
     """Returns the loaded module for this name/path, or None if not found.
 

--- a/src/googleclouddebugger/labels.py
+++ b/src/googleclouddebugger/labels.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Defines the keys of the well known labels used by the cloud debugger.
 
 TODO:  Define these strings in a common format for all agents to

--- a/src/googleclouddebugger/module_explorer.py
+++ b/src/googleclouddebugger/module_explorer.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Finds all the code objects defined by a module."""
 
 import gc
@@ -154,6 +153,7 @@ def _FindCodeObjectsReferents(module, start_objects, visit_recorder):
   Returns:
     List of code objects.
   """
+
   def CheckIgnoreCodeObject(code_object):
     """Checks if the code object can be ignored.
 
@@ -188,9 +188,8 @@ def _FindCodeObjectsReferents(module, start_objects, visit_recorder):
     if not cls_module:
       return False  # We can't tell for sure, so explore this class.
 
-    return (
-        cls_module is not module and
-        getattr(cls_module, '__file__', None) != module.__file__)
+    return (cls_module is not module and
+            getattr(cls_module, '__file__', None) != module.__file__)
 
   code_objects = set()
   current = start_objects

--- a/src/googleclouddebugger/module_search2.py
+++ b/src/googleclouddebugger/module_search2.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Inclusive search for module files."""
 
 import os
@@ -68,6 +67,7 @@ def Search(path):
     AssertionError: if the provided path is an absolute path, or if it does not
       have a .py extension.
   """
+
   def SearchCandidates(p):
     """Generates all candidates for the fuzzy search of p."""
     while p:
@@ -103,4 +103,3 @@ def Search(path):
 
   # A matching file was not found in sys.path directories.
   return path
-

--- a/src/googleclouddebugger/module_utils2.py
+++ b/src/googleclouddebugger/module_utils2.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Provides utility functions for module path processing."""
 
 import os
@@ -29,9 +28,8 @@ def IsPathSuffix(mod_path, path):
   Returns:
     True if path is a full path suffix of mod_path. False otherwise.
   """
-  return (mod_path.endswith(path) and
-          (len(mod_path) == len(path) or
-           mod_path[:-len(path)].endswith(os.sep)))
+  return (mod_path.endswith(path) and (len(mod_path) == len(path) or
+                                       mod_path[:-len(path)].endswith(os.sep)))
 
 
 def GetLoadedModuleBySuffix(path):

--- a/src/googleclouddebugger/python_breakpoint.py
+++ b/src/googleclouddebugger/python_breakpoint.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Handles a single Python breakpoint."""
 
 from datetime import datetime
@@ -36,8 +35,7 @@ ERROR_LOCATION_MODULE_NOT_FOUND_0 = (
     'version of the service you are trying to debug.')
 ERROR_LOCATION_MULTIPLE_MODULES_1 = (
     'Multiple modules matching $0. Please specify the module path.')
-ERROR_LOCATION_MULTIPLE_MODULES_3 = (
-    'Multiple modules matching $0 ($1, $2)')
+ERROR_LOCATION_MULTIPLE_MODULES_3 = ('Multiple modules matching $0 ($1, $2)')
 ERROR_LOCATION_MULTIPLE_MODULES_4 = (
     'Multiple modules matching $0 ($1, $2, and $3 more)')
 ERROR_LOCATION_NO_CODE_FOUND_AT_LINE_2 = 'No code found at line $0 in $1'
@@ -54,30 +52,40 @@ ERROR_CONDITION_BREAKPOINT_QUOTA_EXCEEDED_0 = (
     'the snapshot to a less frequently called statement.')
 ERROR_CONDITION_MUTABLE_0 = (
     'Only immutable expressions can be used in snapshot conditions')
-ERROR_AGE_SNAPSHOT_EXPIRED_0 = (
-    'The snapshot has expired')
-ERROR_AGE_LOGPOINT_EXPIRED_0 = (
-    'The logpoint has expired')
-ERROR_UNSPECIFIED_INTERNAL_ERROR = (
-    'Internal error occurred')
+ERROR_AGE_SNAPSHOT_EXPIRED_0 = ('The snapshot has expired')
+ERROR_AGE_LOGPOINT_EXPIRED_0 = ('The logpoint has expired')
+ERROR_UNSPECIFIED_INTERNAL_ERROR = ('Internal error occurred')
 
 # Status messages for different breakpoint events (except of "hit").
-_BREAKPOINT_EVENT_STATUS = dict(
-    [(native.BREAKPOINT_EVENT_ERROR,
-      {'isError': True,
-       'description': {'format': ERROR_UNSPECIFIED_INTERNAL_ERROR}}),
-     (native.BREAKPOINT_EVENT_GLOBAL_CONDITION_QUOTA_EXCEEDED,
-      {'isError': True,
-       'refersTo': 'BREAKPOINT_CONDITION',
-       'description': {'format': ERROR_CONDITION_GLOBAL_QUOTA_EXCEEDED_0}}),
-     (native.BREAKPOINT_EVENT_BREAKPOINT_CONDITION_QUOTA_EXCEEDED,
-      {'isError': True,
-       'refersTo': 'BREAKPOINT_CONDITION',
-       'description': {'format': ERROR_CONDITION_BREAKPOINT_QUOTA_EXCEEDED_0}}),
-     (native.BREAKPOINT_EVENT_CONDITION_EXPRESSION_MUTABLE,
-      {'isError': True,
-       'refersTo': 'BREAKPOINT_CONDITION',
-       'description': {'format': ERROR_CONDITION_MUTABLE_0}})])
+_BREAKPOINT_EVENT_STATUS = dict([
+    (native.BREAKPOINT_EVENT_ERROR, {
+        'isError': True,
+        'description': {
+            'format': ERROR_UNSPECIFIED_INTERNAL_ERROR
+        }
+    }),
+    (native.BREAKPOINT_EVENT_GLOBAL_CONDITION_QUOTA_EXCEEDED, {
+        'isError': True,
+        'refersTo': 'BREAKPOINT_CONDITION',
+        'description': {
+            'format': ERROR_CONDITION_GLOBAL_QUOTA_EXCEEDED_0
+        }
+    }),
+    (native.BREAKPOINT_EVENT_BREAKPOINT_CONDITION_QUOTA_EXCEEDED, {
+        'isError': True,
+        'refersTo': 'BREAKPOINT_CONDITION',
+        'description': {
+            'format': ERROR_CONDITION_BREAKPOINT_QUOTA_EXCEEDED_0
+        }
+    }),
+    (native.BREAKPOINT_EVENT_CONDITION_EXPRESSION_MUTABLE, {
+        'isError': True,
+        'refersTo': 'BREAKPOINT_CONDITION',
+        'description': {
+            'format': ERROR_CONDITION_MUTABLE_0
+        }
+    })
+])
 
 # The implementation of datetime.strptime imports an undocumented module called
 # _strptime. If it happens at the wrong time, we can get an exception about
@@ -196,7 +204,11 @@ class PythonBreakpoint(object):
           'status': {
               'isError': True,
               'refersTo': 'BREAKPOINT_SOURCE_LOCATION',
-              'description': {'format': ERROR_LOCATION_FILE_EXTENSION_0}}})
+              'description': {
+                  'format': ERROR_LOCATION_FILE_EXTENSION_0
+              }
+          }
+      })
       return
 
     # A flat init file is too generic; path must include package name.
@@ -207,7 +219,10 @@ class PythonBreakpoint(object):
               'refersTo': 'BREAKPOINT_SOURCE_LOCATION',
               'description': {
                   'format': ERROR_LOCATION_MULTIPLE_MODULES_1,
-                  'parameters': [path]}}})
+                  'parameters': [path]
+              }
+          }
+      })
       return
 
     new_path = module_search2.Search(path)
@@ -217,8 +232,7 @@ class PythonBreakpoint(object):
       self._ActivateBreakpoint(new_module)
     else:
       self._import_hook_cleanup = imphook2.AddImportCallbackBySuffix(
-          new_path,
-          self._ActivateBreakpoint)
+          new_path, self._ActivateBreakpoint)
 
   def Clear(self):
     """Clears the breakpoint and releases all breakpoint resources.
@@ -263,7 +277,11 @@ class PythonBreakpoint(object):
         'status': {
             'isError': True,
             'refersTo': 'BREAKPOINT_AGE',
-            'description': {'format': message}}})
+            'description': {
+                'format': message
+            }
+        }
+    })
 
   def _ActivateBreakpoint(self, module):
     """Sets the breakpoint in the loaded module, or complete with error."""
@@ -300,16 +318,18 @@ class PythonBreakpoint(object):
               'refersTo': 'BREAKPOINT_SOURCE_LOCATION',
               'description': {
                   'format': fmt,
-                  'parameters': params}}})
+                  'parameters': params
+              }
+          }
+      })
       return
 
     # Compile the breakpoint condition.
     condition = None
     if self.definition.get('condition'):
       try:
-        condition = compile(self.definition.get('condition'),
-                            '<condition_expression>',
-                            'eval')
+        condition = compile(
+            self.definition.get('condition'), '<condition_expression>', 'eval')
       except (TypeError, ValueError) as e:
         # condition string contains null bytes.
         self._CompleteBreakpoint({
@@ -318,7 +338,10 @@ class PythonBreakpoint(object):
                 'refersTo': 'BREAKPOINT_CONDITION',
                 'description': {
                     'format': 'Invalid expression',
-                    'parameters': [str(e)]}}})
+                    'parameters': [str(e)]
+                }
+            }
+        })
         return
 
       except SyntaxError as e:
@@ -328,17 +351,17 @@ class PythonBreakpoint(object):
                 'refersTo': 'BREAKPOINT_CONDITION',
                 'description': {
                     'format': 'Expression could not be compiled: $0',
-                    'parameters': [e.msg]}}})
+                    'parameters': [e.msg]
+                }
+            }
+        })
         return
 
-    native.LogInfo('Creating new Python breakpoint %s in %s, line %d' % (
-        self.GetBreakpointId(), codeobj, line))
+    native.LogInfo('Creating new Python breakpoint %s in %s, line %d' %
+                   (self.GetBreakpointId(), codeobj, line))
 
-    self._cookie = native.CreateConditionalBreakpoint(
-        codeobj,
-        line,
-        condition,
-        self._BreakpointEvent)
+    self._cookie = native.CreateConditionalBreakpoint(codeobj, line, condition,
+                                                      self._BreakpointEvent)
 
     native.ActivateConditionalBreakpoint(self._cookie)
 
@@ -397,8 +420,8 @@ class PythonBreakpoint(object):
       self._CompleteBreakpoint({'status': error_status})
       return
 
-    collector = capture_collector.CaptureCollector(
-        self.definition, self.data_visibility_policy)
+    collector = capture_collector.CaptureCollector(self.definition,
+                                                   self.data_visibility_policy)
 
     # TODO: This is a temporary try/except. All exceptions should be
     # caught inside Collect and converted into breakpoint error messages.
@@ -406,17 +429,22 @@ class PythonBreakpoint(object):
       collector.Collect(frame)
     except BaseException as e:  # pylint: disable=broad-except
       native.LogInfo('Internal error during data capture: %s' % repr(e))
-      error_status = {'isError': True,
-                      'description': {
-                          'format': ('Internal error while capturing data: %s' %
-                                     repr(e))}}
+      error_status = {
+          'isError': True,
+          'description': {
+              'format': ('Internal error while capturing data: %s' % repr(e))
+          }
+      }
       self._CompleteBreakpoint({'status': error_status})
       return
     except:  # pylint: disable=bare-except
       native.LogInfo('Unknown exception raised')
-      error_status = {'isError': True,
-                      'description': {
-                          'format': 'Unknown internal error'}}
+      error_status = {
+          'isError': True,
+          'description': {
+              'format': 'Unknown internal error'
+          }
+      }
       self._CompleteBreakpoint({'status': error_status})
       return
 

--- a/src/googleclouddebugger/uniquifier_computer.py
+++ b/src/googleclouddebugger/uniquifier_computer.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Computes a unique identifier of the deployed application.
 
 When the application runs under AppEngine, the deployment is uniquely
@@ -27,7 +26,6 @@ breakpoints.
 
 import os
 import sys
-
 
 # Maximum recursion depth to follow when traversing the file system. This limit
 # will prevent stack overflow in case of a loop created by symbolic links.
@@ -93,8 +91,7 @@ def ComputeApplicationUniquifier(hash_obj):
         modules.add(file_name)
         ProcessApplicationFile(current_path, os.path.join(relative_path, name))
       elif IsPackage(current_path):
-        ProcessDirectory(current_path,
-                         os.path.join(relative_path, name),
+        ProcessDirectory(current_path, os.path.join(relative_path, name),
                          depth + 1)
 
   def IsPackage(path):

--- a/src/googleclouddebugger/yaml_data_visibility_config_reader.py
+++ b/src/googleclouddebugger/yaml_data_visibility_config_reader.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Reads a YAML configuration file to determine visibility policy.
 
 Example Usage:
@@ -114,8 +113,7 @@ def Read(f):
 
   try:
     return Config(
-        yaml_data.get('blacklist', ()),
-        yaml_data.get('whitelist', ('*')))
+        yaml_data.get('blacklist', ()), yaml_data.get('whitelist', ('*')))
   except UnicodeDecodeError as e:
     raise YAMLLoadError('%s' % e)
 
@@ -125,8 +123,8 @@ def _CheckData(yaml_data):
   legal_keys = set(('blacklist', 'whitelist'))
   unknown_keys = set(yaml_data) - legal_keys
   if unknown_keys:
-    raise UnknownConfigKeyError(
-        'Unknown keys in configuration: %s' % unknown_keys)
+    raise UnknownConfigKeyError('Unknown keys in configuration: %s' %
+                                unknown_keys)
 
   for key, data in six.iteritems(yaml_data):
     _AssertDataIsList(key, data)

--- a/tests/application_info_test.py
+++ b/tests/application_info_test.py
@@ -42,8 +42,7 @@ class ApplicationInfoTest(absltest.TestCase):
     """Returns correct region when the FUNCTION_REGION env variable is set."""
     try:
       os.environ['FUNCTION_REGION'] = 'function-region'
-      self.assertEqual('function-region',
-                       application_info.GetRegion())
+      self.assertEqual('function-region', application_info.GetRegion())
     finally:
       del os.environ['FUNCTION_REGION']
 
@@ -67,6 +66,7 @@ class ApplicationInfoTest(absltest.TestCase):
     mock_requests_get.return_value = failed_response
 
     self.assertIsNone(application_info.GetRegion())
+
 
 if __name__ == '__main__':
   absltest.main()

--- a/tests/breakpoints_manager_test.py
+++ b/tests/breakpoints_manager_test.py
@@ -28,21 +28,25 @@ class BreakpointsManagerTest(absltest.TestCase):
 
   def testSetSingle(self):
     self._breakpoints_manager.SetActiveBreakpoints([{'id': 'ID1'}])
-    self._mock_breakpoint.assert_has_calls([
-        mock.call({'id': 'ID1'}, self, self._breakpoints_manager, None)])
+    self._mock_breakpoint.assert_has_calls(
+        [mock.call({'id': 'ID1'}, self, self._breakpoints_manager, None)])
     self.assertLen(self._breakpoints_manager._active, 1)
 
   def testSetDouble(self):
     self._breakpoints_manager.SetActiveBreakpoints([{'id': 'ID1'}])
-    self._mock_breakpoint.assert_has_calls([
-        mock.call({'id': 'ID1'}, self, self._breakpoints_manager, None)])
+    self._mock_breakpoint.assert_has_calls(
+        [mock.call({'id': 'ID1'}, self, self._breakpoints_manager, None)])
     self.assertLen(self._breakpoints_manager._active, 1)
 
-    self._breakpoints_manager.SetActiveBreakpoints(
-        [{'id': 'ID1'}, {'id': 'ID2'}])
+    self._breakpoints_manager.SetActiveBreakpoints([{
+        'id': 'ID1'
+    }, {
+        'id': 'ID2'
+    }])
     self._mock_breakpoint.assert_has_calls([
         mock.call({'id': 'ID1'}, self, self._breakpoints_manager, None),
-        mock.call({'id': 'ID2'}, self, self._breakpoints_manager, None)])
+        mock.call({'id': 'ID2'}, self, self._breakpoints_manager, None)
+    ])
     self.assertLen(self._breakpoints_manager._active, 2)
 
   def testSetRepeated(self):
@@ -76,28 +80,52 @@ class BreakpointsManagerTest(absltest.TestCase):
     self.assertEqual(1, self._mock_breakpoint.call_count)
 
   def testMultipleSetDelete(self):
-    self._breakpoints_manager.SetActiveBreakpoints(
-        [{'id': 'ID1'}, {'id': 'ID2'}, {'id': 'ID3'}, {'id': 'ID4'}])
+    self._breakpoints_manager.SetActiveBreakpoints([{
+        'id': 'ID1'
+    }, {
+        'id': 'ID2'
+    }, {
+        'id': 'ID3'
+    }, {
+        'id': 'ID4'
+    }])
     self.assertLen(self._breakpoints_manager._active, 4)
 
-    self._breakpoints_manager.SetActiveBreakpoints(
-        [{'id': 'ID1'}, {'id': 'ID2'}, {'id': 'ID3'}, {'id': 'ID4'}])
+    self._breakpoints_manager.SetActiveBreakpoints([{
+        'id': 'ID1'
+    }, {
+        'id': 'ID2'
+    }, {
+        'id': 'ID3'
+    }, {
+        'id': 'ID4'
+    }])
     self.assertLen(self._breakpoints_manager._active, 4)
 
     self._breakpoints_manager.SetActiveBreakpoints([])
     self.assertEmpty(self._breakpoints_manager._active)
 
   def testCombination(self):
-    self._breakpoints_manager.SetActiveBreakpoints(
-        [{'id': 'ID1'}, {'id': 'ID2'}, {'id': 'ID3'}])
+    self._breakpoints_manager.SetActiveBreakpoints([{
+        'id': 'ID1'
+    }, {
+        'id': 'ID2'
+    }, {
+        'id': 'ID3'
+    }])
     self.assertLen(self._breakpoints_manager._active, 3)
 
     self._breakpoints_manager.CompleteBreakpoint('ID2')
     self.assertEqual(1, self._mock_breakpoint.return_value.Clear.call_count)
     self.assertLen(self._breakpoints_manager._active, 2)
 
-    self._breakpoints_manager.SetActiveBreakpoints(
-        [{'id': 'ID2'}, {'id': 'ID3'}, {'id': 'ID4'}])
+    self._breakpoints_manager.SetActiveBreakpoints([{
+        'id': 'ID2'
+    }, {
+        'id': 'ID3'
+    }, {
+        'id': 'ID4'
+    }])
     self.assertEqual(2, self._mock_breakpoint.return_value.Clear.call_count)
     self.assertLen(self._breakpoints_manager._active, 2)
 
@@ -113,24 +141,28 @@ class BreakpointsManagerTest(absltest.TestCase):
     self._breakpoints_manager.CheckBreakpointsExpiration()
 
   def testCheckNotExpired(self):
-    self._breakpoints_manager.SetActiveBreakpoints(
-        [{'id': 'ID1'}, {'id': 'ID2'}])
+    self._breakpoints_manager.SetActiveBreakpoints([{
+        'id': 'ID1'
+    }, {
+        'id': 'ID2'
+    }])
     self._mock_breakpoint.return_value.GetExpirationTime.return_value = (
         datetime.utcnow() + timedelta(minutes=1))
     self._breakpoints_manager.CheckBreakpointsExpiration()
     self.assertEqual(
-        0,
-        self._mock_breakpoint.return_value.ExpireBreakpoint.call_count)
+        0, self._mock_breakpoint.return_value.ExpireBreakpoint.call_count)
 
   def testCheckExpired(self):
-    self._breakpoints_manager.SetActiveBreakpoints(
-        [{'id': 'ID1'}, {'id': 'ID2'}])
+    self._breakpoints_manager.SetActiveBreakpoints([{
+        'id': 'ID1'
+    }, {
+        'id': 'ID2'
+    }])
     self._mock_breakpoint.return_value.GetExpirationTime.return_value = (
         datetime.utcnow() - timedelta(minutes=1))
     self._breakpoints_manager.CheckBreakpointsExpiration()
     self.assertEqual(
-        2,
-        self._mock_breakpoint.return_value.ExpireBreakpoint.call_count)
+        2, self._mock_breakpoint.return_value.ExpireBreakpoint.call_count)
 
   def testCheckExpirationReset(self):
     self._breakpoints_manager.SetActiveBreakpoints([{'id': 'ID1'}])
@@ -138,17 +170,18 @@ class BreakpointsManagerTest(absltest.TestCase):
         datetime.utcnow() + timedelta(minutes=1))
     self._breakpoints_manager.CheckBreakpointsExpiration()
     self.assertEqual(
-        0,
-        self._mock_breakpoint.return_value.ExpireBreakpoint.call_count)
+        0, self._mock_breakpoint.return_value.ExpireBreakpoint.call_count)
 
-    self._breakpoints_manager.SetActiveBreakpoints(
-        [{'id': 'ID1'}, {'id': 'ID2'}])
+    self._breakpoints_manager.SetActiveBreakpoints([{
+        'id': 'ID1'
+    }, {
+        'id': 'ID2'
+    }])
     self._mock_breakpoint.return_value.GetExpirationTime.return_value = (
         datetime.utcnow() - timedelta(minutes=1))
     self._breakpoints_manager.CheckBreakpointsExpiration()
     self.assertEqual(
-        2,
-        self._mock_breakpoint.return_value.ExpireBreakpoint.call_count)
+        2, self._mock_breakpoint.return_value.ExpireBreakpoint.call_count)
 
   def testCheckExpirationCacheNegative(self):
     base = datetime(2015, 1, 1)
@@ -163,16 +196,14 @@ class BreakpointsManagerTest(absltest.TestCase):
 
       self._breakpoints_manager.CheckBreakpointsExpiration()
       self.assertEqual(
-          0,
-          self._mock_breakpoint.return_value.ExpireBreakpoint.call_count)
+          0, self._mock_breakpoint.return_value.ExpireBreakpoint.call_count)
 
       # The nearest expiration time is cached, so this should have no effect.
       self._mock_breakpoint.return_value.GetExpirationTime.return_value = (
           base - timedelta(minutes=1))
       self._breakpoints_manager.CheckBreakpointsExpiration()
       self.assertEqual(
-          0,
-          self._mock_breakpoint.return_value.ExpireBreakpoint.call_count)
+          0, self._mock_breakpoint.return_value.ExpireBreakpoint.call_count)
 
   def testCheckExpirationCachePositive(self):
     base = datetime(2015, 1, 1)
@@ -186,14 +217,12 @@ class BreakpointsManagerTest(absltest.TestCase):
       mock_time.return_value = base
       self._breakpoints_manager.CheckBreakpointsExpiration()
       self.assertEqual(
-          0,
-          self._mock_breakpoint.return_value.ExpireBreakpoint.call_count)
+          0, self._mock_breakpoint.return_value.ExpireBreakpoint.call_count)
 
       mock_time.return_value = base + timedelta(minutes=2)
       self._breakpoints_manager.CheckBreakpointsExpiration()
       self.assertEqual(
-          1,
-          self._mock_breakpoint.return_value.ExpireBreakpoint.call_count)
+          1, self._mock_breakpoint.return_value.ExpireBreakpoint.call_count)
 
 
 if __name__ == '__main__':

--- a/tests/capture_collector_test.py
+++ b/tests/capture_collector_test.py
@@ -20,8 +20,8 @@ LOGPOINT_PAUSE_MSG = (
     'quota is restored')
 
 
-def CaptureCollectorWithDefaultLocation(
-    definition, data_visibility_policy=None):
+def CaptureCollectorWithDefaultLocation(definition,
+                                        data_visibility_policy=None):
   """Makes a LogCollector with a default location.
 
   Args:
@@ -80,6 +80,7 @@ class CaptureCollectorTest(absltest.TestCase):
     self.assertEqual(frame_below_line, frame_below['location']['line'])
 
   def testCallStackLimitedExpandedFrames(self):
+
     def CountLocals(frame):
       return len(frame['arguments']) + len(frame['locals'])
 
@@ -99,10 +100,15 @@ class CaptureCollectorTest(absltest.TestCase):
     def Method(unused_a, unused_b):
       self._collector.Collect(inspect.currentframe())
       top_frame = self._collector.breakpoint['stackFrames'][0]
-      self.assertListEqual(
-          [{'name': 'unused_a', 'value': '158', 'type': 'int'},
-           {'name': 'unused_b', 'value': "'hello'", 'type': 'str'}],
-          top_frame['arguments'])
+      self.assertListEqual([{
+          'name': 'unused_a',
+          'value': '158',
+          'type': 'int'
+      }, {
+          'name': 'unused_b',
+          'value': "'hello'",
+          'type': 'str'
+      }], top_frame['arguments'])
       self.assertEqual('Method', top_frame['function'])
 
     self._collector = CaptureCollectorWithDefaultLocation({'id': 'BP_ID'})
@@ -114,11 +120,19 @@ class CaptureCollectorTest(absltest.TestCase):
     def Method(self, unused_a, unused_b):  # pylint: disable=unused-argument
       this._collector.Collect(inspect.currentframe())
       top_frame = this._collector.breakpoint['stackFrames'][0]
-      this.assertListEqual(
-          [{'name': 'self', 'value': "'world'", 'type': 'str'},
-           {'name': 'unused_a', 'value': '158', 'type': 'int'},
-           {'name': 'unused_b', 'value': "'hello'", 'type': 'str'}],
-          top_frame['arguments'])
+      this.assertListEqual([{
+          'name': 'self',
+          'value': "'world'",
+          'type': 'str'
+      }, {
+          'name': 'unused_a',
+          'value': '158',
+          'type': 'int'
+      }, {
+          'name': 'unused_b',
+          'value': "'hello'",
+          'type': 'str'
+      }], top_frame['arguments'])
       # This is the incorrect function name, but we are validating that no
       # exceptions are thrown here.
       this.assertEqual('str.Method', top_frame['function'])
@@ -132,11 +146,19 @@ class CaptureCollectorTest(absltest.TestCase):
     def Method(unused_a, unused_b, self):  # pylint: disable=unused-argument
       this._collector.Collect(inspect.currentframe())
       top_frame = this._collector.breakpoint['stackFrames'][0]
-      this.assertListEqual(
-          [{'name': 'unused_a', 'value': '158', 'type': 'int'},
-           {'name': 'unused_b', 'value': "'hello'", 'type': 'str'},
-           {'name': 'self', 'value': "'world'", 'type': 'str'}],
-          top_frame['arguments'])
+      this.assertListEqual([{
+          'name': 'unused_a',
+          'value': '158',
+          'type': 'int'
+      }, {
+          'name': 'unused_b',
+          'value': "'hello'",
+          'type': 'str'
+      }, {
+          'name': 'self',
+          'value': "'world'",
+          'type': 'str'
+      }], top_frame['arguments'])
       this.assertEqual('Method', top_frame['function'])
 
     self._collector = CaptureCollectorWithDefaultLocation({'id': 'BP_ID'})
@@ -146,9 +168,10 @@ class CaptureCollectorTest(absltest.TestCase):
     self._collector = CaptureCollectorWithDefaultLocation({'id': 'BP_ID'})
     self._collector.Collect(inspect.currentframe())
     top_frame = self._collector.breakpoint['stackFrames'][0]
-    self.assertListEqual(
-        [{'name': 'self', 'varTableIndex': 1}],
-        top_frame['arguments'])
+    self.assertListEqual([{
+        'name': 'self',
+        'varTableIndex': 1
+    }], top_frame['arguments'])
     self.assertEqual('CaptureCollectorTest.testClassMethod',
                      top_frame['function'])
 
@@ -157,10 +180,14 @@ class CaptureCollectorTest(absltest.TestCase):
     def Method(unused_a, unused_optional='notneeded'):
       self._collector.Collect(inspect.currentframe())
       top_frame = self._collector.breakpoint['stackFrames'][0]
-      self.assertListEqual(
-          [{'name': 'unused_a', 'varTableIndex': 1},
-           {'name': 'unused_optional', 'value': "'notneeded'", 'type': 'str'}],
-          top_frame['arguments'])
+      self.assertListEqual([{
+          'name': 'unused_a',
+          'varTableIndex': 1
+      }, {
+          'name': 'unused_optional',
+          'value': "'notneeded'",
+          'type': 'str'
+      }], top_frame['arguments'])
       self.assertEqual('Method', top_frame['function'])
 
     self._collector = CaptureCollectorWithDefaultLocation({'id': 'BP_ID'})
@@ -171,11 +198,15 @@ class CaptureCollectorTest(absltest.TestCase):
     def Method(*unused_pos):
       self._collector.Collect(inspect.currentframe())
       top_frame = self._collector.breakpoint['stackFrames'][0]
-      self.assertListEqual(
-          [{'name': 'unused_pos',
-            'type': 'tuple',
-            'members': [{'name': '[0]', 'value': '1', 'type': 'int'}]}],
-          top_frame['arguments'])
+      self.assertListEqual([{
+          'name': 'unused_pos',
+          'type': 'tuple',
+          'members': [{
+              'name': '[0]',
+              'value': '1',
+              'type': 'int'
+          }]
+      }], top_frame['arguments'])
       self.assertEqual('Method', top_frame['function'])
 
     self._collector = CaptureCollectorWithDefaultLocation({'id': 'BP_ID'})
@@ -186,10 +217,15 @@ class CaptureCollectorTest(absltest.TestCase):
     def Method(**unused_kwd):
       self._collector.Collect(inspect.currentframe())
       top_frame = self._collector.breakpoint['stackFrames'][0]
-      self.assertCountEqual(
-          [{'name': "'first'", 'value': '1', 'type': 'int'},
-           {'name': "'second'", 'value': '2', 'type': 'int'}],
-          top_frame['arguments'][0]['members'])
+      self.assertCountEqual([{
+          'name': "'first'",
+          'value': '1',
+          'type': 'int'
+      }, {
+          'name': "'second'",
+          'value': '2',
+          'type': 'int'
+      }], top_frame['arguments'][0]['members'])
       self.assertEqual('Method', top_frame['function'])
 
     self._collector = CaptureCollectorWithDefaultLocation({'id': 'BP_ID'})
@@ -204,6 +240,7 @@ class CaptureCollectorTest(absltest.TestCase):
                      top_frame['function'])
 
   def testRuntimeError(self):
+
     class BadDict(dict):
 
       def __init__(self, d):
@@ -238,6 +275,7 @@ class CaptureCollectorTest(absltest.TestCase):
         }, var_a)
 
   def testBadDictionary(self):
+
     class BadDict(dict):
 
       def items(self):
@@ -281,12 +319,22 @@ class CaptureCollectorTest(absltest.TestCase):
     self._collector.Collect(inspect.currentframe())
     top_frame = self._collector.breakpoint['stackFrames'][0]
     self.assertLen(top_frame['arguments'], 1)  # just self.
-    self.assertCountEqual(
-        [{'name': 'unused_a', 'value': '8', 'type': 'int'},
-         {'name': 'unused_b', 'value': 'True', 'type': 'bool'},
-         {'name': 'unused_nothing', 'value': 'None'},
-         {'name': 'unused_s', 'value': "'hippo'", 'type': 'str'}],
-        top_frame['locals'])
+    self.assertCountEqual([{
+        'name': 'unused_a',
+        'value': '8',
+        'type': 'int'
+    }, {
+        'name': 'unused_b',
+        'value': 'True',
+        'type': 'bool'
+    }, {
+        'name': 'unused_nothing',
+        'value': 'None'
+    }, {
+        'name': 'unused_s',
+        'value': "'hippo'",
+        'type': 'str'
+    }], top_frame['locals'])
 
   def testLocalVariablesWithBlacklist(self):
     unused_a = capture_collector.LineNoFilter()
@@ -302,9 +350,8 @@ class CaptureCollectorTest(absltest.TestCase):
     mock_policy = mock.MagicMock()
     mock_policy.IsDataVisible.side_effect = IsDataVisible
 
-    self._collector = CaptureCollectorWithDefaultLocation(
-        {'id': 'BP_ID'},
-        mock_policy)
+    self._collector = CaptureCollectorWithDefaultLocation({'id': 'BP_ID'},
+                                                          mock_policy)
     self._collector.Collect(inspect.currentframe())
     top_frame = self._collector.breakpoint['stackFrames'][0]
     # Should be blocked
@@ -312,22 +359,22 @@ class CaptureCollectorTest(absltest.TestCase):
         {
             'name': 'unused_a',
             'status': {
-                'description': {'format': 'data blocked'},
+                'description': {
+                    'format': 'data blocked'
+                },
                 'refersTo': 'VARIABLE_NAME',
                 'isError': True
             }
-        },
-        top_frame['locals'])
+        }, top_frame['locals'])
     # Should not be blocked
-    self.assertIn(
-        {
-            'name': 'unused_b',
-            'value': '5',
-            'type': 'int'
-        },
-        top_frame['locals'])
+    self.assertIn({
+        'name': 'unused_b',
+        'value': '5',
+        'type': 'int'
+    }, top_frame['locals'])
 
   def testWatchedExpressionsBlacklisted(self):
+
     class TestClass(object):
 
       def __init__(self):
@@ -340,6 +387,7 @@ class CaptureCollectorTest(absltest.TestCase):
       if name == 'capture_collector_test.TestClass':
         return (False, 'data blocked')
       return (True, None)
+
     mock_policy = mock.MagicMock()
     mock_policy.IsDataVisible.side_effect = IsDataVisible
 
@@ -347,42 +395,45 @@ class CaptureCollectorTest(absltest.TestCase):
         {
             'id': 'BP_ID',
             'expressions': ['unused_a', 'unused_a.a']
-        },
-        mock_policy)
+        }, mock_policy)
     self._collector.Collect(inspect.currentframe())
     # Class should be blocked
     self.assertIn(
         {
             'name': 'unused_a',
             'status': {
-                'description': {'format': 'data blocked'},
+                'description': {
+                    'format': 'data blocked'
+                },
                 'refersTo': 'VARIABLE_NAME',
                 'isError': True
             }
-        },
-        self._collector.breakpoint['evaluatedExpressions'])
+        }, self._collector.breakpoint['evaluatedExpressions'])
     # TODO: Explicit member SHOULD also be blocked but this is
     # currently not implemented.  After fixing the implementation, change
     # the test below to assert that it's blocked too.
-    self.assertIn(
-        {
-            'name': 'unused_a.a',
-            'type': 'int',
-            'value': '5'
-        },
-        self._collector.breakpoint['evaluatedExpressions'])
+    self.assertIn({
+        'name': 'unused_a.a',
+        'type': 'int',
+        'value': '5'
+    }, self._collector.breakpoint['evaluatedExpressions'])
 
   def testLocalsNonTopFrame(self):
 
     def Method():
       self._collector.Collect(inspect.currentframe())
-      self.assertListEqual(
-          [{'name': 'self', 'varTableIndex': 1}],
-          self._collector.breakpoint['stackFrames'][1]['arguments'])
-      self.assertCountEqual(
-          [{'name': 'unused_a', 'value': '47', 'type': 'int'},
-           {'name': 'Method', 'value': 'function Method'}],
-          self._collector.breakpoint['stackFrames'][1]['locals'])
+      self.assertListEqual([{
+          'name': 'self',
+          'varTableIndex': 1
+      }], self._collector.breakpoint['stackFrames'][1]['arguments'])
+      self.assertCountEqual([{
+          'name': 'unused_a',
+          'value': '47',
+          'type': 'int'
+      }, {
+          'name': 'Method',
+          'value': 'function Method'
+      }], self._collector.breakpoint['stackFrames'][1]['locals'])
 
     unused_a = 47
     self._collector = CaptureCollectorWithDefaultLocation({'id': 'BP_ID'})
@@ -399,12 +450,20 @@ class CaptureCollectorTest(absltest.TestCase):
     self._collector.default_capture_limits.max_depth = 3
     self._collector.Collect(inspect.currentframe())
     self.assertDictEqual(
-        {'name': 'd',
-         'type': 'dict',
-         'members': [{'name': "'inner'",
-                      'type': 'dict',
-                      'members': [{'name': "'inner'", 'varTableIndex': 0}]}]},
-        self._LocalByName('d'))
+        {
+            'name':
+                'd',
+            'type':
+                'dict',
+            'members': [{
+                'name': "'inner'",
+                'type': 'dict',
+                'members': [{
+                    'name': "'inner'",
+                    'varTableIndex': 0
+                }]
+            }]
+        }, self._LocalByName('d'))
 
   def testVectorMaxDepth(self):
     l = []
@@ -417,31 +476,42 @@ class CaptureCollectorTest(absltest.TestCase):
     self._collector.default_capture_limits.max_depth = 3
     self._collector.Collect(inspect.currentframe())
     self.assertDictEqual(
-        {'name': 'l',
-         'type': 'list',
-         'members': [{'name': '[0]',
-                      'type': 'list',
-                      'members': [{'name': '[0]', 'varTableIndex': 0}]}]},
-        self._LocalByName('l'))
+        {
+            'name':
+                'l',
+            'type':
+                'list',
+            'members': [{
+                'name': '[0]',
+                'type': 'list',
+                'members': [{
+                    'name': '[0]',
+                    'varTableIndex': 0
+                }]
+            }]
+        }, self._LocalByName('l'))
 
   def testStringTrimming(self):
     unused_s = '123456789'
     self._collector = CaptureCollectorWithDefaultLocation({'id': 'BP_ID'})
     self._collector.default_capture_limits.max_value_len = 8
     self._collector.Collect(inspect.currentframe())
-    self.assertListEqual(
-        [{'name': 'unused_s', 'value': "'12345678...", 'type': 'str'}],
-        self._collector.breakpoint['stackFrames'][0]['locals'])
+    self.assertListEqual([{
+        'name': 'unused_s',
+        'value': "'12345678...",
+        'type': 'str'
+    }], self._collector.breakpoint['stackFrames'][0]['locals'])
 
   def testBytearrayTrimming(self):
     unused_bytes = bytearray(range(20))
     self._collector = CaptureCollectorWithDefaultLocation({'id': 'BP_ID'})
     self._collector.default_capture_limits.max_value_len = 20
     self._collector.Collect(inspect.currentframe())
-    self.assertListEqual(
-        [{'name': 'unused_bytes', 'value': r"bytearray(b'\x00\x01\...",
-          'type': 'bytearray'}],
-        self._collector.breakpoint['stackFrames'][0]['locals'])
+    self.assertListEqual([{
+        'name': 'unused_bytes',
+        'value': r"bytearray(b'\x00\x01\...",
+        'type': 'bytearray'
+    }], self._collector.breakpoint['stackFrames'][0]['locals'])
 
   def testObject(self):
 
@@ -458,10 +528,15 @@ class CaptureCollectorTest(absltest.TestCase):
     self.assertEqual(
         __name__ + '.MyClass',
         self._collector.breakpoint['variableTable'][var_index]['type'])
-    self.assertCountEqual(
-        [{'name': 'a', 'value': '1', 'type': 'int'},
-         {'name': 'b', 'value': '2', 'type': 'int'}],
-        self._collector.breakpoint['variableTable'][var_index]['members'])
+    self.assertCountEqual([{
+        'name': 'a',
+        'value': '1',
+        'type': 'int'
+    }, {
+        'name': 'b',
+        'value': '2',
+        'type': 'int'
+    }], self._collector.breakpoint['variableTable'][var_index]['members'])
 
   def testBufferFullLocalRef(self):
 
@@ -514,8 +589,10 @@ class CaptureCollectorTest(absltest.TestCase):
       self._collector.Collect(inspect.currentframe())
 
       # Verify that one of {d1,d2} could fit and the other didn't.
-      var_indexes = [self._LocalByName(n)['members'][0]['varTableIndex'] == 0
-                     for n in ['unused_d1', 'unused_d2']]
+      var_indexes = [
+          self._LocalByName(n)['members'][0]['varTableIndex'] == 0
+          for n in ['unused_d1', 'unused_d2']
+      ]
       self.assertEqual(1, sum(var_indexes))
 
     Method()
@@ -538,13 +615,21 @@ class CaptureCollectorTest(absltest.TestCase):
 
     var_table = self._collector.breakpoint['variableTable']
     self.assertDictEqual(
-        {'type': __name__ + '.MyClass',
-         'members': [{'name': 'other', 'varTableIndex': m1_var_index}]},
-        var_table[m2_var_index])
+        {
+            'type': __name__ + '.MyClass',
+            'members': [{
+                'name': 'other',
+                'varTableIndex': m1_var_index
+            }]
+        }, var_table[m2_var_index])
     self.assertDictEqual(
-        {'type': __name__ + '.MyClass',
-         'members': [{'name': 'other', 'varTableIndex': m2_var_index}]},
-        var_table[m1_var_index])
+        {
+            'type': __name__ + '.MyClass',
+            'members': [{
+                'name': 'other',
+                'varTableIndex': m2_var_index
+            }]
+        }, var_table[m1_var_index])
 
   def testCaptureVector(self):
     unused_my_list = [1, 2, 3, 4, 5]
@@ -554,21 +639,53 @@ class CaptureCollectorTest(absltest.TestCase):
     self._collector.Collect(inspect.currentframe())
 
     self.assertDictEqual(
-        {'name': 'unused_my_list',
-         'type': 'list',
-         'members': [{'name': '[0]', 'value': '1', 'type': 'int'},
-                     {'name': '[1]', 'value': '2', 'type': 'int'},
-                     {'name': '[2]', 'value': '3', 'type': 'int'},
-                     {'name': '[3]', 'value': '4', 'type': 'int'},
-                     {'name': '[4]', 'value': '5', 'type': 'int'}]},
-        self._LocalByName('unused_my_list'))
+        {
+            'name':
+                'unused_my_list',
+            'type':
+                'list',
+            'members': [{
+                'name': '[0]',
+                'value': '1',
+                'type': 'int'
+            }, {
+                'name': '[1]',
+                'value': '2',
+                'type': 'int'
+            }, {
+                'name': '[2]',
+                'value': '3',
+                'type': 'int'
+            }, {
+                'name': '[3]',
+                'value': '4',
+                'type': 'int'
+            }, {
+                'name': '[4]',
+                'value': '5',
+                'type': 'int'
+            }]
+        }, self._LocalByName('unused_my_list'))
     self.assertDictEqual(
-        {'name': 'unused_my_slice',
-         'type': 'list',
-         'members': [{'name': '[0]', 'value': '2', 'type': 'int'},
-                     {'name': '[1]', 'value': '3', 'type': 'int'},
-                     {'name': '[2]', 'value': '4', 'type': 'int'}]},
-        self._LocalByName('unused_my_slice'))
+        {
+            'name':
+                'unused_my_slice',
+            'type':
+                'list',
+            'members': [{
+                'name': '[0]',
+                'value': '2',
+                'type': 'int'
+            }, {
+                'name': '[1]',
+                'value': '3',
+                'type': 'int'
+            }, {
+                'name': '[2]',
+                'value': '4',
+                'type': 'int'
+            }]
+        }, self._LocalByName('unused_my_slice'))
 
   def testCaptureDictionary(self):
     unused_my_dict = {
@@ -577,33 +694,73 @@ class CaptureCollectorTest(absltest.TestCase):
         (5, 6): 7,
         frozenset([5, 6]): 'frozen',
         'vector': ['odin', 'dva', 'tri'],
-        'inner': {1: 'one'},
-        'empty': {}}
+        'inner': {
+            1: 'one'
+        },
+        'empty': {}
+    }
 
     self._collector = CaptureCollectorWithDefaultLocation({'id': 'BP_ID'})
     self._collector.Collect(inspect.currentframe())
 
     frozenset_name = 'frozenset({5, 6})' if six.PY3 else 'frozenset([5, 6])'
-    self.assertCountEqual(
-        [{'name': "'first'", 'value': '1', 'type': 'int'},
-         {'name': '3.14', 'value': "'pi'", 'type': 'str'},
-         {'name': '(5, 6)', 'value': '7', 'type': 'int'},
-         {'name': frozenset_name, 'value': "'frozen'", 'type': 'str'},
-         {'name': "'vector'",
-          'type': 'list',
-          'members': [{'name': '[0]', 'value': "'odin'", 'type': 'str'},
-                      {'name': '[1]', 'value': "'dva'", 'type': 'str'},
-                      {'name': '[2]', 'value': "'tri'", 'type': 'str'}]},
-         {'name': "'inner'",
-          'type': 'dict',
-          'members': [{'name': '1', 'value': "'one'", 'type': 'str'}]},
-         {'name': "'empty'",
-          'type': 'dict',
-          'members': [
-              {'status': {
-                  'refersTo': 'VARIABLE_NAME',
-                  'description': {'format': 'Empty dictionary'}}}]}],
-        self._LocalByName('unused_my_dict')['members'])
+    self.assertCountEqual([{
+        'name': "'first'",
+        'value': '1',
+        'type': 'int'
+    }, {
+        'name': '3.14',
+        'value': "'pi'",
+        'type': 'str'
+    }, {
+        'name': '(5, 6)',
+        'value': '7',
+        'type': 'int'
+    }, {
+        'name': frozenset_name,
+        'value': "'frozen'",
+        'type': 'str'
+    }, {
+        'name':
+            "'vector'",
+        'type':
+            'list',
+        'members': [{
+            'name': '[0]',
+            'value': "'odin'",
+            'type': 'str'
+        }, {
+            'name': '[1]',
+            'value': "'dva'",
+            'type': 'str'
+        }, {
+            'name': '[2]',
+            'value': "'tri'",
+            'type': 'str'
+        }]
+    }, {
+        'name': "'inner'",
+        'type': 'dict',
+        'members': [{
+            'name': '1',
+            'value': "'one'",
+            'type': 'str'
+        }]
+    }, {
+        'name':
+            "'empty'",
+        'type':
+            'dict',
+        'members': [{
+            'status': {
+                'refersTo': 'VARIABLE_NAME',
+                'description': {
+                    'format': 'Empty dictionary'
+                }
+            }
+        }]
+    }],
+                          self._LocalByName('unused_my_dict')['members'])
 
   def testEscapeDictionaryKey(self):
     unused_dict = {}
@@ -617,10 +774,16 @@ class CaptureCollectorTest(absltest.TestCase):
     unicode_name = "'\xe0'" if six.PY3 else "u'\\xe0'"
     unicode_value = "'\xe0'" if six.PY3 else "u'\\xe0'"
 
-    self.assertCountEqual(
-        [{'type': 'str', 'name': "'\\x88'", 'value': "'\\x88'"},
-         {'type': unicode_type, 'name': unicode_name, 'value': unicode_value}],
-        self._LocalByName('unused_dict')['members'])
+    self.assertCountEqual([{
+        'type': 'str',
+        'name': "'\\x88'",
+        'value': "'\\x88'"
+    }, {
+        'type': unicode_type,
+        'name': unicode_name,
+        'value': unicode_value
+    }],
+                          self._LocalByName('unused_dict')['members'])
 
   def testOversizedList(self):
     unused_big_list = ['x'] * 10000
@@ -631,17 +794,23 @@ class CaptureCollectorTest(absltest.TestCase):
     members = self._LocalByName('unused_big_list')['members']
 
     self.assertLen(members, 26)
-    self.assertDictEqual({'name': '[7]', 'value': "'x'", 'type': 'str'},
-                         members[7])
+    self.assertDictEqual({
+        'name': '[7]',
+        'value': "'x'",
+        'type': 'str'
+    }, members[7])
     self.assertDictEqual(
-        {'status': {
-            'refersTo': 'VARIABLE_VALUE',
-            'description': {
-                'format':
-                    ('Only first $0 items were captured. Use in an expression'
-                     ' to see all items.'),
-                'parameters': ['25']}}},
-        members[25])
+        {
+            'status': {
+                'refersTo': 'VARIABLE_VALUE',
+                'description': {
+                    'format': (
+                        'Only first $0 items were captured. Use in an expression'
+                        ' to see all items.'),
+                    'parameters': ['25']
+                }
+            }
+        }, members[25])
 
   def testOversizedDictionary(self):
     unused_big_dict = {'item' + str(i): i**2 for i in range(26)}
@@ -653,14 +822,17 @@ class CaptureCollectorTest(absltest.TestCase):
 
     self.assertLen(members, 26)
     self.assertDictEqual(
-        {'status': {
-            'refersTo': 'VARIABLE_VALUE',
-            'description': {
-                'format':
-                    ('Only first $0 items were captured. Use in an expression'
-                     ' to see all items.'),
-                'parameters': ['25']}}},
-        members[25])
+        {
+            'status': {
+                'refersTo': 'VARIABLE_VALUE',
+                'description': {
+                    'format': (
+                        'Only first $0 items were captured. Use in an expression'
+                        ' to see all items.'),
+                    'parameters': ['25']
+                }
+            }
+        }, members[25])
 
   def testEmptyDictionary(self):
     unused_empty_dict = {}
@@ -669,13 +841,20 @@ class CaptureCollectorTest(absltest.TestCase):
     self._collector.Collect(inspect.currentframe())
 
     self.assertEqual(
-        {'name': 'unused_empty_dict',
-         'type': 'dict',
-         'members': [{
-             'status': {
-                 'refersTo': 'VARIABLE_NAME',
-                 'description': {'format': 'Empty dictionary'}}}]},
-        self._LocalByName('unused_empty_dict'))
+        {
+            'name':
+                'unused_empty_dict',
+            'type':
+                'dict',
+            'members': [{
+                'status': {
+                    'refersTo': 'VARIABLE_NAME',
+                    'description': {
+                        'format': 'Empty dictionary'
+                    }
+                }
+            }]
+        }, self._LocalByName('unused_empty_dict'))
 
   def testEmptyCollection(self):
     for unused_c, object_type in [([], 'list'), ((), 'tuple'), (set(), 'set')]:
@@ -683,13 +862,20 @@ class CaptureCollectorTest(absltest.TestCase):
       self._collector.Collect(inspect.currentframe())
 
       self.assertEqual(
-          {'name': 'unused_c',
-           'type': object_type,
-           'members': [{
-               'status': {
-                   'refersTo': 'VARIABLE_NAME',
-                   'description': {'format': 'Empty collection'}}}]},
-          self._Pack(self._LocalByName('unused_c')))
+          {
+              'name':
+                  'unused_c',
+              'type':
+                  object_type,
+              'members': [{
+                  'status': {
+                      'refersTo': 'VARIABLE_NAME',
+                      'description': {
+                          'format': 'Empty collection'
+                      }
+                  }
+              }]
+          }, self._Pack(self._LocalByName('unused_c')))
 
   def testEmptyClass(self):
 
@@ -702,13 +888,20 @@ class CaptureCollectorTest(absltest.TestCase):
     self._collector.Collect(inspect.currentframe())
 
     self.assertEqual(
-        {'name': 'unused_empty_object',
-         'type': __name__ + '.EmptyObject',
-         'members': [{
-             'status': {
-                 'refersTo': 'VARIABLE_NAME',
-                 'description': {'format': 'Object has no fields'}}}]},
-        self._Pack(self._LocalByName('unused_empty_object')))
+        {
+            'name':
+                'unused_empty_object',
+            'type':
+                __name__ + '.EmptyObject',
+            'members': [{
+                'status': {
+                    'refersTo': 'VARIABLE_NAME',
+                    'description': {
+                        'format': 'Object has no fields'
+                    }
+                }
+            }]
+        }, self._Pack(self._LocalByName('unused_empty_object')))
 
   def testWatchedExpressionsSuccess(self):
     unused_dummy_a = 'x'
@@ -716,16 +909,32 @@ class CaptureCollectorTest(absltest.TestCase):
 
     self._collector = CaptureCollectorWithDefaultLocation({
         'id': 'BP_ID',
-        'expressions': ['1+2', 'unused_dummy_a*8', 'unused_dummy_b']})
+        'expressions': ['1+2', 'unused_dummy_a*8', 'unused_dummy_b']
+    })
     self._collector.Collect(inspect.currentframe())
-    self.assertListEqual(
-        [{'name': '1+2', 'value': '3', 'type': 'int'},
-         {'name': 'unused_dummy_a*8', 'value': "'xxxxxxxx'", 'type': 'str'},
-         {'name': 'unused_dummy_b',
-          'type': 'dict',
-          'members': [{'name': '1', 'value': '2', 'type': 'int'},
-                      {'name': '3', 'value': "'a'", 'type': 'str'}]}],
-        self._collector.breakpoint['evaluatedExpressions'])
+    self.assertListEqual([{
+        'name': '1+2',
+        'value': '3',
+        'type': 'int'
+    }, {
+        'name': 'unused_dummy_a*8',
+        'value': "'xxxxxxxx'",
+        'type': 'str'
+    }, {
+        'name':
+            'unused_dummy_b',
+        'type':
+            'dict',
+        'members': [{
+            'name': '1',
+            'value': '2',
+            'type': 'int'
+        }, {
+            'name': '3',
+            'value': "'a'",
+            'type': 'str'
+        }]
+    }], self._collector.breakpoint['evaluatedExpressions'])
 
   def testOversizedStringExpression(self):
     # This test checks that string expressions are collected first, up to the
@@ -737,33 +946,42 @@ class CaptureCollectorTest(absltest.TestCase):
     # ensure that we're not using the normal limit of 256 bytes.
     self._collector = CaptureCollectorWithDefaultLocation({
         'id': 'BP_ID',
-        'expressions': ['unused_dummy_a']})
+        'expressions': ['unused_dummy_a']
+    })
     self._collector.max_size = 500
     unused_dummy_a = '|'.join(['%04d' % i for i in range(5, 510, 5)])
     self._collector.Collect(inspect.currentframe())
-    self.assertListEqual(
-        [{'name': 'unused_dummy_a',
-          'type': 'str',
-          'value': "'{0}...".format(unused_dummy_a[0:-18])}],
-        self._collector.breakpoint['evaluatedExpressions'])
+    self.assertListEqual([{
+        'name': 'unused_dummy_a',
+        'type': 'str',
+        'value': "'{0}...".format(unused_dummy_a[0:-18])
+    }], self._collector.breakpoint['evaluatedExpressions'])
 
   def testOversizedListExpression(self):
     self._collector = CaptureCollectorWithDefaultLocation({
         'id': 'BP_ID',
-        'expressions': ['unused_dummy_a']})
+        'expressions': ['unused_dummy_a']
+    })
     unused_dummy_a = list(range(0, 100))
     self._collector.Collect(inspect.currentframe())
     # Verify that the list did not get truncated.
-    self.assertListEqual(
-        [{'name': 'unused_dummy_a', 'type': 'list', 'members': [
-            {'type': 'int', 'value': str(a), 'name': '[{0}]'.format(a)}
-            for a in unused_dummy_a]}],
-        self._collector.breakpoint['evaluatedExpressions'])
+    self.assertListEqual([{
+        'name':
+            'unused_dummy_a',
+        'type':
+            'list',
+        'members': [{
+            'type': 'int',
+            'value': str(a),
+            'name': '[{0}]'.format(a)
+        } for a in unused_dummy_a]
+    }], self._collector.breakpoint['evaluatedExpressions'])
 
   def testExpressionNullBytes(self):
     self._collector = CaptureCollectorWithDefaultLocation({
         'id': 'BP_ID',
-        'expressions': ['\0']})
+        'expressions': ['\0']
+    })
     self._collector.Collect(inspect.currentframe())
 
     evaluated_expressions = self._collector.breakpoint['evaluatedExpressions']
@@ -773,36 +991,39 @@ class CaptureCollectorTest(absltest.TestCase):
   def testSyntaxErrorExpression(self):
     self._collector = CaptureCollectorWithDefaultLocation({
         'id': 'BP_ID',
-        'expressions': ['2+']})
+        'expressions': ['2+']
+    })
     self._collector.Collect(inspect.currentframe())
 
     evaluated_expressions = self._collector.breakpoint['evaluatedExpressions']
     self.assertLen(evaluated_expressions, 1)
     self.assertTrue(evaluated_expressions[0]['status']['isError'])
-    self.assertEqual(
-        'VARIABLE_NAME',
-        evaluated_expressions[0]['status']['refersTo'])
+    self.assertEqual('VARIABLE_NAME',
+                     evaluated_expressions[0]['status']['refersTo'])
 
   def testExpressionException(self):
     unused_dummy_a = 1
     unused_dummy_b = 0
     self._collector = CaptureCollectorWithDefaultLocation({
         'id': 'BP_ID',
-        'expressions': ['unused_dummy_a/unused_dummy_b']})
+        'expressions': ['unused_dummy_a/unused_dummy_b']
+    })
     self._collector.Collect(inspect.currentframe())
 
     zero_division_msg = ('division by zero'
                          if six.PY3 else 'integer division or modulo by zero')
 
-    self.assertListEqual(
-        [{'name': 'unused_dummy_a/unused_dummy_b',
-          'status': {
-              'isError': True,
-              'refersTo': 'VARIABLE_VALUE',
-              'description': {
-                  'format': 'Exception occurred: $0',
-                  'parameters': [zero_division_msg]}}}],
-        self._collector.breakpoint['evaluatedExpressions'])
+    self.assertListEqual([{
+        'name': 'unused_dummy_a/unused_dummy_b',
+        'status': {
+            'isError': True,
+            'refersTo': 'VARIABLE_VALUE',
+            'description': {
+                'format': 'Exception occurred: $0',
+                'parameters': [zero_division_msg]
+            }
+        }
+    }], self._collector.breakpoint['evaluatedExpressions'])
 
   def testMutableExpression(self):
 
@@ -813,20 +1034,24 @@ class CaptureCollectorTest(absltest.TestCase):
     ChangeA()
     self._collector = CaptureCollectorWithDefaultLocation({
         'id': 'BP_ID',
-        'expressions': ['ChangeA()']})
+        'expressions': ['ChangeA()']
+    })
     self._collector.Collect(inspect.currentframe())
 
     self.assertEqual(1, self._a)
-    self.assertListEqual(
-        [{'name': 'ChangeA()',
-          'status': {
-              'isError': True,
-              'refersTo': 'VARIABLE_VALUE',
-              'description': {
-                  'format': 'Exception occurred: $0',
-                  'parameters': [('Only immutable methods can be '
-                                  'called from expressions')]}}}],
-        self._collector.breakpoint['evaluatedExpressions'])
+    self.assertListEqual([{
+        'name': 'ChangeA()',
+        'status': {
+            'isError': True,
+            'refersTo': 'VARIABLE_VALUE',
+            'description': {
+                'format':
+                    'Exception occurred: $0',
+                'parameters': [('Only immutable methods can be '
+                                'called from expressions')]
+            }
+        }
+    }], self._collector.breakpoint['evaluatedExpressions'])
 
   def testPrettyPrinters(self):
 
@@ -844,7 +1069,8 @@ class CaptureCollectorTest(absltest.TestCase):
       return ((('name2_%d' % i, '2_%d' % i) for i in range(3)), 'pp-type2')
 
     capture_collector.CaptureCollector.pretty_printers += [
-        PrettyPrinter1, PrettyPrinter2]
+        PrettyPrinter1, PrettyPrinter2
+    ]
 
     unused_obj1 = MyClass()
     unused_obj2 = MyClass()
@@ -853,29 +1079,56 @@ class CaptureCollectorTest(absltest.TestCase):
     self._collector = CaptureCollectorWithDefaultLocation({'id': 'BP_ID'})
     self._collector.Collect(inspect.currentframe())
 
-    obj_vars = [self._Pack(self._LocalByName('unused_obj%d' % i))
-                for i in range(1, 4)]
+    obj_vars = [
+        self._Pack(self._LocalByName('unused_obj%d' % i)) for i in range(1, 4)
+    ]
 
-    self.assertListEqual(
-        [
-            {'name': 'unused_obj1',
-             'type': 'pp-type1',
-             'members': [
-                 {'name': 'name1_0', 'value': "'1_0'", 'type': 'str'},
-                 {'name': 'name1_1', 'value': "'1_1'", 'type': 'str'}]},
-            {'name': 'unused_obj2',
-             'type': 'pp-type2',
-             'members': [
-                 {'name': 'name2_0', 'value': "'2_0'", 'type': 'str'},
-                 {'name': 'name2_1', 'value': "'2_1'", 'type': 'str'},
-                 {'name': 'name2_2', 'value': "'2_2'", 'type': 'str'}]},
-            {'name': 'unused_obj3',
-             'type': __name__ + '.MyClass',
-             'members': [
-                 {'status': {
-                     'refersTo': 'VARIABLE_NAME',
-                     'description': {'format': 'Object has no fields'}}}]}],
-        obj_vars)
+    self.assertListEqual([{
+        'name':
+            'unused_obj1',
+        'type':
+            'pp-type1',
+        'members': [{
+            'name': 'name1_0',
+            'value': "'1_0'",
+            'type': 'str'
+        }, {
+            'name': 'name1_1',
+            'value': "'1_1'",
+            'type': 'str'
+        }]
+    }, {
+        'name':
+            'unused_obj2',
+        'type':
+            'pp-type2',
+        'members': [{
+            'name': 'name2_0',
+            'value': "'2_0'",
+            'type': 'str'
+        }, {
+            'name': 'name2_1',
+            'value': "'2_1'",
+            'type': 'str'
+        }, {
+            'name': 'name2_2',
+            'value': "'2_2'",
+            'type': 'str'
+        }]
+    }, {
+        'name':
+            'unused_obj3',
+        'type':
+            __name__ + '.MyClass',
+        'members': [{
+            'status': {
+                'refersTo': 'VARIABLE_NAME',
+                'description': {
+                    'format': 'Object has no fields'
+                }
+            }
+        }]
+    }], obj_vars)
 
   def testDateTime(self):
     unused_datetime = datetime.datetime(2014, 6, 11, 2, 30)
@@ -887,28 +1140,32 @@ class CaptureCollectorTest(absltest.TestCase):
     self._collector.Collect(inspect.currentframe())
 
     self.assertDictEqual(
-        {'name': 'unused_datetime',
-         'type': 'datetime.datetime',
-         'value': '2014-06-11 02:30:00'},
-        self._Pack(self._LocalByName('unused_datetime')))
+        {
+            'name': 'unused_datetime',
+            'type': 'datetime.datetime',
+            'value': '2014-06-11 02:30:00'
+        }, self._Pack(self._LocalByName('unused_datetime')))
 
     self.assertDictEqual(
-        {'name': 'unused_date',
-         'type': 'datetime.datetime',
-         'value': '1980-03-01 00:00:00'},
-        self._Pack(self._LocalByName('unused_date')))
+        {
+            'name': 'unused_date',
+            'type': 'datetime.datetime',
+            'value': '1980-03-01 00:00:00'
+        }, self._Pack(self._LocalByName('unused_date')))
 
     self.assertDictEqual(
-        {'name': 'unused_time',
-         'type': 'datetime.time',
-         'value': '18:43:11'},
-        self._Pack(self._LocalByName('unused_time')))
+        {
+            'name': 'unused_time',
+            'type': 'datetime.time',
+            'value': '18:43:11'
+        }, self._Pack(self._LocalByName('unused_time')))
 
     self.assertDictEqual(
-        {'name': 'unused_timedelta',
-         'type': 'datetime.timedelta',
-         'value': '3 days, 0:00:00.008237'},
-        self._Pack(self._LocalByName('unused_timedelta')))
+        {
+            'name': 'unused_timedelta',
+            'type': 'datetime.timedelta',
+            'value': '3 days, 0:00:00.008237'
+        }, self._Pack(self._LocalByName('unused_timedelta')))
 
   def testException(self):
     unused_exception = ValueError('arg1', 2, [3])
@@ -919,12 +1176,23 @@ class CaptureCollectorTest(absltest.TestCase):
 
     self.assertEqual('unused_exception', obj['name'])
     self.assertEqual('ValueError', obj['type'])
-    self.assertListEqual([
-        {'value': "'arg1'", 'type': 'str', 'name': '[0]'},
-        {'value': '2', 'type': 'int', 'name': '[1]'},
-        {'members': [{'value': '3', 'type': 'int', 'name': '[0]'}],
-         'type': 'list',
-         'name': '[2]'}], obj['members'])
+    self.assertListEqual([{
+        'value': "'arg1'",
+        'type': 'str',
+        'name': '[0]'
+    }, {
+        'value': '2',
+        'type': 'int',
+        'name': '[1]'
+    }, {
+        'members': [{
+            'value': '3',
+            'type': 'int',
+            'name': '[0]'
+        }],
+        'type': 'list',
+        'name': '[2]'
+    }], obj['members'])
 
   def testRequestLogIdCapturing(self):
     capture_collector.request_log_id_collector = lambda: 'test_log_id'
@@ -952,12 +1220,10 @@ class CaptureCollectorTest(absltest.TestCase):
     self._collector.Collect(inspect.currentframe())
 
     self.assertIn('evaluatedUserId', self._collector.breakpoint)
-    self.assertEqual(
-        {
-            'kind': 'mdb_user',
-            'id': 'noogler'
-        },
-        self._collector.breakpoint['evaluatedUserId'])
+    self.assertEqual({
+        'kind': 'mdb_user',
+        'id': 'noogler'
+    }, self._collector.breakpoint['evaluatedUserId'])
 
   def testUserIdIsNone(self):
     capture_collector.user_id_collector = lambda: (None, None)
@@ -997,8 +1263,9 @@ class CaptureCollectorTest(absltest.TestCase):
       del packed_variable['varTableIndex']
 
     if 'members' in packed_variable:
-      packed_variable['members'] = [self._Pack(member) for member
-                                    in packed_variable['members']]
+      packed_variable['members'] = [
+          self._Pack(member) for member in packed_variable['members']
+      ]
 
     return packed_variable
 
@@ -1018,7 +1285,10 @@ class LogCollectorTest(absltest.TestCase):
       def emit(self, record):
         self._received_records.append(record)
 
-      def GotMessage(self, msg, level=logging.INFO, line_number=10,
+      def GotMessage(self,
+                     msg,
+                     level=logging.INFO,
+                     line_number=10,
                      func_name=None):
         """Checks that the given message was logged correctly.
 
@@ -1037,8 +1307,8 @@ class LogCollectorTest(absltest.TestCase):
         record = self._received_records.pop(0)
         frame = inspect.currentframe().f_back
         if level != record.levelno:
-          logging.error('Expected log level %d, got %d (%s)',
-                        level, record.levelno, record.levelname)
+          logging.error('Expected log level %d, got %d (%s)', level,
+                        record.levelno, record.levelname)
           return False
         if msg != record.msg:
           logging.error('Expected msg "%s", received "%s"', msg, record.msg)
@@ -1053,12 +1323,12 @@ class LogCollectorTest(absltest.TestCase):
                         os.path.basename(pathname), record.filename)
           return False
         if func_name and func_name != record.funcName:
-          logging.error('Expected function "%s", received "%s"',
-                        func_name, record.funcName)
+          logging.error('Expected function "%s", received "%s"', func_name,
+                        record.funcName)
           return False
         if line_number and record.lineno != line_number:
-          logging.error('Expected lineno %d, received %d',
-                        line_number, record.lineno)
+          logging.error('Expected lineno %d, received %d', line_number,
+                        record.lineno)
           return False
         for attr in ['cdbg_pathname', 'cdbg_lineno']:
           if hasattr(record, attr):
@@ -1114,20 +1384,23 @@ class LogCollectorTest(absltest.TestCase):
     # recover so the ordering of tests ideally doesn't affect this test.
     self.ResetGlobalLogQuota()
     bucket_max_capacity = 250
-    collector = LogCollectorWithDefaultLocation(
-        {'logMessageFormat': '$0', 'expressions': ['i']})
+    collector = LogCollectorWithDefaultLocation({
+        'logMessageFormat': '$0',
+        'expressions': ['i']
+    })
     for i in range(0, bucket_max_capacity * 2):
       self.assertIsNone(collector.Log(inspect.currentframe()))
       if not self._verifier.CheckMessageSafe('LOGPOINT: %s' % i):
-        self.assertGreaterEqual(
-            i, bucket_max_capacity,
-            'Log quota exhausted earlier than expected')
-        self.assertTrue(self._verifier.CheckMessageSafe(LOGPOINT_PAUSE_MSG),
-                        'Quota hit message not logged')
+        self.assertGreaterEqual(i, bucket_max_capacity,
+                                'Log quota exhausted earlier than expected')
+        self.assertTrue(
+            self._verifier.CheckMessageSafe(LOGPOINT_PAUSE_MSG),
+            'Quota hit message not logged')
         time.sleep(0.6)
         self.assertIsNone(collector.Log(inspect.currentframe()))
-        self.assertTrue(self._verifier.CheckMessageSafe('LOGPOINT: %s' % i),
-                        'Logging not resumed after quota recovery time')
+        self.assertTrue(
+            self._verifier.CheckMessageSafe('LOGPOINT: %s' % i),
+            'Logging not resumed after quota recovery time')
         return
     self.fail('Logging was never paused when quota was exceeded')
 
@@ -1140,15 +1413,15 @@ class LogCollectorTest(absltest.TestCase):
     # implemented, it can allow effectively twice that amount to go out in a
     # very short time frame. So the third 30k message should pause.
     msg = ' ' * 30000
-    collector = LogCollectorWithDefaultLocation(
-        {'logMessageFormat': msg})
+    collector = LogCollectorWithDefaultLocation({'logMessageFormat': msg})
     self.assertIsNone(collector.Log(inspect.currentframe()))
     self.assertTrue(self._verifier.GotMessage('LOGPOINT: ' + msg))
     self.assertIsNone(collector.Log(inspect.currentframe()))
     self.assertTrue(self._verifier.GotMessage('LOGPOINT: ' + msg))
     self.assertIsNone(collector.Log(inspect.currentframe()))
-    self.assertTrue(self._verifier.CheckMessageSafe(LOGPOINT_PAUSE_MSG),
-                    'Quota hit message not logged')
+    self.assertTrue(
+        self._verifier.CheckMessageSafe(LOGPOINT_PAUSE_MSG),
+        'Quota hit message not logged')
     time.sleep(0.6)
     collector._definition['logMessageFormat'] = 'hello'
     self.assertIsNone(collector.Log(inspect.currentframe()))
@@ -1158,8 +1431,7 @@ class LogCollectorTest(absltest.TestCase):
 
   def testMissingLogLevel(self):
     # Missing is equivalent to INFO.
-    collector = LogCollectorWithDefaultLocation(
-        {'logMessageFormat': 'hello'})
+    collector = LogCollectorWithDefaultLocation({'logMessageFormat': 'hello'})
     self.assertIsNone(collector.Log(inspect.currentframe()))
     self.assertTrue(self._verifier.GotMessage('LOGPOINT: hello'))
 
@@ -1167,13 +1439,18 @@ class LogCollectorTest(absltest.TestCase):
     capture_collector.log_info_message = None
     collector = LogCollectorWithDefaultLocation({'logLevel': 'INFO'})
     self.assertDictEqual(
-        {'isError': True,
-         'description': {'format': 'Log action on a breakpoint not supported'}},
-        collector.Log(inspect.currentframe()))
+        {
+            'isError': True,
+            'description': {
+                'format': 'Log action on a breakpoint not supported'
+            }
+        }, collector.Log(inspect.currentframe()))
 
   def testLogInfo(self):
-    collector = LogCollectorWithDefaultLocation(
-        {'logLevel': 'INFO', 'logMessageFormat': 'hello'})
+    collector = LogCollectorWithDefaultLocation({
+        'logLevel': 'INFO',
+        'logMessageFormat': 'hello'
+    })
     collector._definition['location']['line'] = 20
     self.assertIsNone(collector.Log(inspect.currentframe()))
     self.assertTrue(
@@ -1183,8 +1460,10 @@ class LogCollectorTest(absltest.TestCase):
             line_number=20))
 
   def testLogWarning(self):
-    collector = LogCollectorWithDefaultLocation(
-        {'logLevel': 'WARNING', 'logMessageFormat': 'hello'})
+    collector = LogCollectorWithDefaultLocation({
+        'logLevel': 'WARNING',
+        'logMessageFormat': 'hello'
+    })
     self.assertIsNone(collector.Log(inspect.currentframe()))
     self.assertTrue(
         self._verifier.GotMessage(
@@ -1193,8 +1472,10 @@ class LogCollectorTest(absltest.TestCase):
             func_name='LogCollectorTest.testLogWarning'))
 
   def testLogError(self):
-    collector = LogCollectorWithDefaultLocation(
-        {'logLevel': 'ERROR', 'logMessageFormat': 'hello'})
+    collector = LogCollectorWithDefaultLocation({
+        'logLevel': 'ERROR',
+        'logMessageFormat': 'hello'
+    })
     self.assertIsNone(collector.Log(inspect.currentframe()))
     self.assertTrue(
         self._verifier.GotMessage(
@@ -1203,15 +1484,17 @@ class LogCollectorTest(absltest.TestCase):
             func_name='LogCollectorTest.testLogError'))
 
   def testBadExpression(self):
-    collector = LogCollectorWithDefaultLocation(
-        {'logLevel': 'INFO',
-         'logMessageFormat': 'a=$0, b=$1',
-         'expressions': ['-', '+']})
+    collector = LogCollectorWithDefaultLocation({
+        'logLevel': 'INFO',
+        'logMessageFormat': 'a=$0, b=$1',
+        'expressions': ['-', '+']
+    })
     self.assertIsNone(collector.Log(inspect.currentframe()))
-    self.assertTrue(self._verifier.GotMessage(
-        'LOGPOINT: a=<Expression could not be compiled: unexpected EOF while '
-        'parsing>, b=<Expression could not be compiled: unexpected EOF while '
-        'parsing>'))
+    self.assertTrue(
+        self._verifier.GotMessage(
+            'LOGPOINT: a=<Expression could not be compiled: unexpected EOF while '
+            'parsing>, b=<Expression could not be compiled: unexpected EOF while '
+            'parsing>'))
 
   def testDollarEscape(self):
     unused_integer = 12345
@@ -1226,42 +1509,48 @@ class LogCollectorTest(absltest.TestCase):
     self.assertTrue(self._verifier.GotMessage(msg))
 
   def testInvalidExpressionIndex(self):
-    collector = LogCollectorWithDefaultLocation(
-        {'logLevel': 'INFO',
-         'logMessageFormat': 'a=$0'})
+    collector = LogCollectorWithDefaultLocation({
+        'logLevel': 'INFO',
+        'logMessageFormat': 'a=$0'
+    })
     self.assertIsNone(collector.Log(inspect.currentframe()))
     self.assertTrue(self._verifier.GotMessage('LOGPOINT: a=<N/A>'))
 
   def testException(self):
-    collector = LogCollectorWithDefaultLocation(
-        {'logLevel': 'INFO',
-         'logMessageFormat': '$0',
-         'expressions': ['[][1]']})
+    collector = LogCollectorWithDefaultLocation({
+        'logLevel': 'INFO',
+        'logMessageFormat': '$0',
+        'expressions': ['[][1]']
+    })
     self.assertIsNone(collector.Log(inspect.currentframe()))
-    self.assertTrue(self._verifier.GotMessage(
-        'LOGPOINT: <Exception occurred: list index out of range>'))
+    self.assertTrue(
+        self._verifier.GotMessage(
+            'LOGPOINT: <Exception occurred: list index out of range>'))
 
   def testMutableExpression(self):
 
     def MutableMethod():  # pylint: disable=unused-variable
       self.abc = None
 
-    collector = LogCollectorWithDefaultLocation(
-        {'logLevel': 'INFO',
-         'logMessageFormat': '$0',
-         'expressions': ['MutableMethod()']})
+    collector = LogCollectorWithDefaultLocation({
+        'logLevel': 'INFO',
+        'logMessageFormat': '$0',
+        'expressions': ['MutableMethod()']
+    })
     self.assertIsNone(collector.Log(inspect.currentframe()))
-    self.assertTrue(self._verifier.GotMessage(
-        'LOGPOINT: <Exception occurred: Only immutable methods can be called '
-        'from expressions>'))
+    self.assertTrue(
+        self._verifier.GotMessage(
+            'LOGPOINT: <Exception occurred: Only immutable methods can be called '
+            'from expressions>'))
 
   def testNone(self):
     unused_none = None
 
-    collector = LogCollectorWithDefaultLocation(
-        {'logLevel': 'INFO',
-         'logMessageFormat': '$0',
-         'expressions': ['unused_none']})
+    collector = LogCollectorWithDefaultLocation({
+        'logLevel': 'INFO',
+        'logMessageFormat': '$0',
+        'expressions': ['unused_none']
+    })
     self.assertIsNone(collector.Log(inspect.currentframe()))
     self.assertTrue(self._verifier.GotMessage('LOGPOINT: None'))
 
@@ -1270,20 +1559,22 @@ class LogCollectorTest(absltest.TestCase):
     unused_integer = 12345
     unused_string = 'hello'
 
-    collector = LogCollectorWithDefaultLocation(
-        {'logLevel': 'INFO',
-         'logMessageFormat': '$0,$1,$2',
-         'expressions': ['unused_boolean', 'unused_integer', 'unused_string']})
+    collector = LogCollectorWithDefaultLocation({
+        'logLevel': 'INFO',
+        'logMessageFormat': '$0,$1,$2',
+        'expressions': ['unused_boolean', 'unused_integer', 'unused_string']
+    })
     self.assertIsNone(collector.Log(inspect.currentframe()))
     self.assertTrue(self._verifier.GotMessage("LOGPOINT: True,12345,'hello'"))
 
   def testLongString(self):
     unused_string = '1234567890'
 
-    collector = LogCollectorWithDefaultLocation(
-        {'logLevel': 'INFO',
-         'logMessageFormat': '$0',
-         'expressions': ['unused_string']})
+    collector = LogCollectorWithDefaultLocation({
+        'logLevel': 'INFO',
+        'logMessageFormat': '$0',
+        'expressions': ['unused_string']
+    })
     collector.max_value_len = 9
     self.assertIsNone(collector.Log(inspect.currentframe()))
     self.assertTrue(self._verifier.GotMessage("LOGPOINT: '123456789..."))
@@ -1291,14 +1582,15 @@ class LogCollectorTest(absltest.TestCase):
   def testLongBytes(self):
     unused_bytes = bytearray([i for i in range(20)])
 
-    collector = LogCollectorWithDefaultLocation(
-        {'logLevel': 'INFO',
-         'logMessageFormat': '$0',
-         'expressions': ['unused_bytes']})
+    collector = LogCollectorWithDefaultLocation({
+        'logLevel': 'INFO',
+        'logMessageFormat': '$0',
+        'expressions': ['unused_bytes']
+    })
     collector.max_value_len = 20
     self.assertIsNone(collector.Log(inspect.currentframe()))
-    self.assertTrue(self._verifier.GotMessage(
-        r"LOGPOINT: bytearray(b'\x00\x01\..."))
+    self.assertTrue(
+        self._verifier.GotMessage(r"LOGPOINT: bytearray(b'\x00\x01\..."))
 
   def testDate(self):
     unused_datetime = datetime.datetime(2014, 6, 11, 2, 30)
@@ -1306,53 +1598,62 @@ class LogCollectorTest(absltest.TestCase):
     unused_time = datetime.time(18, 43, 11)
     unused_timedelta = datetime.timedelta(days=3, microseconds=8237)
 
-    collector = LogCollectorWithDefaultLocation(
-        {'logLevel': 'INFO',
-         'logMessageFormat': '$0;$1;$2;$3',
-         'expressions': ['unused_datetime', 'unused_date',
-                         'unused_time', 'unused_timedelta']})
+    collector = LogCollectorWithDefaultLocation({
+        'logLevel':
+            'INFO',
+        'logMessageFormat':
+            '$0;$1;$2;$3',
+        'expressions': [
+            'unused_datetime', 'unused_date', 'unused_time', 'unused_timedelta'
+        ]
+    })
     self.assertIsNone(collector.Log(inspect.currentframe()))
-    self.assertTrue(self._verifier.GotMessage(
-        'LOGPOINT: 2014-06-11 02:30:00;1980-03-01 00:00:00;'
-        '18:43:11;3 days, 0:00:00.008237'))
+    self.assertTrue(
+        self._verifier.GotMessage(
+            'LOGPOINT: 2014-06-11 02:30:00;1980-03-01 00:00:00;'
+            '18:43:11;3 days, 0:00:00.008237'))
 
   def testSet(self):
     unused_set = set(['a'])
 
-    collector = LogCollectorWithDefaultLocation(
-        {'logLevel': 'INFO',
-         'logMessageFormat': '$0',
-         'expressions': ['unused_set']})
+    collector = LogCollectorWithDefaultLocation({
+        'logLevel': 'INFO',
+        'logMessageFormat': '$0',
+        'expressions': ['unused_set']
+    })
     self.assertIsNone(collector.Log(inspect.currentframe()))
     self.assertTrue(self._verifier.GotMessage("LOGPOINT: {'a'}"))
 
   def testTuple(self):
     unused_tuple = (1, 2, 3, 4, 5)
 
-    collector = LogCollectorWithDefaultLocation(
-        {'logLevel': 'INFO',
-         'logMessageFormat': '$0',
-         'expressions': ['unused_tuple']})
+    collector = LogCollectorWithDefaultLocation({
+        'logLevel': 'INFO',
+        'logMessageFormat': '$0',
+        'expressions': ['unused_tuple']
+    })
     self.assertIsNone(collector.Log(inspect.currentframe()))
     self.assertTrue(self._verifier.GotMessage('LOGPOINT: (1, 2, 3, 4, 5)'))
 
   def testList(self):
     unused_list = ['a', 'b', 'c']
 
-    collector = LogCollectorWithDefaultLocation(
-        {'logLevel': 'INFO',
-         'logMessageFormat': '$0',
-         'expressions': ['unused_list']})
+    collector = LogCollectorWithDefaultLocation({
+        'logLevel': 'INFO',
+        'logMessageFormat': '$0',
+        'expressions': ['unused_list']
+    })
     self.assertIsNone(collector.Log(inspect.currentframe()))
     self.assertTrue(self._verifier.GotMessage("LOGPOINT: ['a', 'b', 'c']"))
 
   def testOversizedList(self):
     unused_list = [1, 2, 3, 4]
 
-    collector = LogCollectorWithDefaultLocation(
-        {'logLevel': 'INFO',
-         'logMessageFormat': '$0',
-         'expressions': ['unused_list']})
+    collector = LogCollectorWithDefaultLocation({
+        'logLevel': 'INFO',
+        'logMessageFormat': '$0',
+        'expressions': ['unused_list']
+    })
     collector.max_list_items = 3
     self.assertIsNone(collector.Log(inspect.currentframe()))
     self.assertTrue(self._verifier.GotMessage('LOGPOINT: [1, 2, 3, ...]'))
@@ -1360,10 +1661,11 @@ class LogCollectorTest(absltest.TestCase):
   def testSlice(self):
     unused_slice = slice(1, 10)
 
-    collector = LogCollectorWithDefaultLocation(
-        {'logLevel': 'INFO',
-         'logMessageFormat': '$0',
-         'expressions': ['unused_slice']})
+    collector = LogCollectorWithDefaultLocation({
+        'logLevel': 'INFO',
+        'logMessageFormat': '$0',
+        'expressions': ['unused_slice']
+    })
     collector.max_list_items = 3
     self.assertIsNone(collector.Log(inspect.currentframe()))
     self.assertTrue(self._verifier.GotMessage('LOGPOINT: slice(1, 10, None)'))
@@ -1371,10 +1673,11 @@ class LogCollectorTest(absltest.TestCase):
   def testMap(self):
     unused_map = {'a': 1}
 
-    collector = LogCollectorWithDefaultLocation(
-        {'logLevel': 'INFO',
-         'logMessageFormat': '$0',
-         'expressions': ['unused_map']})
+    collector = LogCollectorWithDefaultLocation({
+        'logLevel': 'INFO',
+        'logMessageFormat': '$0',
+        'expressions': ['unused_map']
+    })
     self.assertIsNone(collector.Log(inspect.currentframe()))
     self.assertTrue(self._verifier.GotMessage("LOGPOINT: {'a': 1}"))
 
@@ -1387,61 +1690,70 @@ class LogCollectorTest(absltest.TestCase):
 
     unused_my = MyClass()
 
-    collector = LogCollectorWithDefaultLocation(
-        {'logLevel': 'INFO',
-         'logMessageFormat': '$0',
-         'expressions': ['unused_my']})
+    collector = LogCollectorWithDefaultLocation({
+        'logLevel': 'INFO',
+        'logMessageFormat': '$0',
+        'expressions': ['unused_my']
+    })
     self.assertIsNone(collector.Log(inspect.currentframe()))
     self.assertTrue(self._verifier.GotMessage("LOGPOINT: {'some': 'thing'}"))
 
   def testNestedBelowLimit(self):
     unused_list = [1, [2], [1, 2, 3], [1, [1, 2, 3]], 5]
 
-    collector = LogCollectorWithDefaultLocation(
-        {'logLevel': 'INFO',
-         'logMessageFormat': '$0',
-         'expressions': ['unused_list']})
+    collector = LogCollectorWithDefaultLocation({
+        'logLevel': 'INFO',
+        'logMessageFormat': '$0',
+        'expressions': ['unused_list']
+    })
     self.assertIsNone(collector.Log(inspect.currentframe()))
-    self.assertTrue(self._verifier.GotMessage(
-        'LOGPOINT: [1, [2], [1, 2, 3], [1, [1, 2, 3]], 5]'))
+    self.assertTrue(
+        self._verifier.GotMessage(
+            'LOGPOINT: [1, [2], [1, 2, 3], [1, [1, 2, 3]], 5]'))
 
   def testNestedAtLimits(self):
     unused_list = [
-        1, [1, 2, 3, 4, 5], [[1, 2, 3, 4, 5], 2, 3, 4, 5], 4, 5, 6, 7, 8, 9]
+        1, [1, 2, 3, 4, 5], [[1, 2, 3, 4, 5], 2, 3, 4, 5], 4, 5, 6, 7, 8, 9
+    ]
 
-    collector = LogCollectorWithDefaultLocation(
-        {'logLevel': 'INFO',
-         'logMessageFormat': '$0',
-         'expressions': ['unused_list']})
+    collector = LogCollectorWithDefaultLocation({
+        'logLevel': 'INFO',
+        'logMessageFormat': '$0',
+        'expressions': ['unused_list']
+    })
     self.assertIsNone(collector.Log(inspect.currentframe()))
-    self.assertTrue(self._verifier.GotMessage(
-        'LOGPOINT: [1, [1, 2, 3, 4, 5], [[1, 2, 3, 4, 5], 2, 3, 4, 5], '
-        '4, 5, 6, 7, 8, 9]'))
+    self.assertTrue(
+        self._verifier.GotMessage(
+            'LOGPOINT: [1, [1, 2, 3, 4, 5], [[1, 2, 3, 4, 5], 2, 3, 4, 5], '
+            '4, 5, 6, 7, 8, 9]'))
 
   def testNestedRecursionLimit(self):
     unused_list = [1, [[2, [3]], 4], 5]
 
-    collector = LogCollectorWithDefaultLocation(
-        {'logLevel': 'INFO',
-         'logMessageFormat': '$0',
-         'expressions': ['unused_list']})
+    collector = LogCollectorWithDefaultLocation({
+        'logLevel': 'INFO',
+        'logMessageFormat': '$0',
+        'expressions': ['unused_list']
+    })
     self.assertIsNone(collector.Log(inspect.currentframe()))
-    self.assertTrue(self._verifier.GotMessage(
-        'LOGPOINT: [1, [[2, %s], 4], 5]' % type([])))
+    self.assertTrue(
+        self._verifier.GotMessage('LOGPOINT: [1, [[2, %s], 4], 5]' % type([])))
 
   def testNestedRecursionItemLimits(self):
     unused_list = [1, [1, [1, [2], 3, 4], 3, 4], 3, 4]
 
     list_type = "<class 'list'>" if six.PY3 else "<type 'list'>"
-    collector = LogCollectorWithDefaultLocation(
-        {'logLevel': 'INFO',
-         'logMessageFormat': '$0',
-         'expressions': ['unused_list']})
+    collector = LogCollectorWithDefaultLocation({
+        'logLevel': 'INFO',
+        'logMessageFormat': '$0',
+        'expressions': ['unused_list']
+    })
     collector.max_list_items = 3
     collector.max_sublist_items = 3
     self.assertIsNone(collector.Log(inspect.currentframe()))
-    self.assertTrue(self._verifier.GotMessage(
-        'LOGPOINT: [1, [1, [1, %s, 3, ...], 3, ...], 3, ...]' % list_type))
+    self.assertTrue(
+        self._verifier.GotMessage(
+            'LOGPOINT: [1, [1, [1, %s, 3, ...], 3, ...], 3, ...]' % list_type))
 
   def testDetermineType(self):
     builtin_prefix = 'builtins.' if six.PY3 else '__builtin__.'
@@ -1450,8 +1762,7 @@ class LogCollectorTest(absltest.TestCase):
         (builtin_prefix + 'int', 5),
         (builtin_prefix + 'str', 'hello'),
         (builtin_prefix + 'function', capture_collector.DetermineType),
-        (path_prefix + 'LineNoFilter',
-         capture_collector.LineNoFilter()),
+        (path_prefix + 'LineNoFilter', capture_collector.LineNoFilter()),
     )
 
     for type_string, value in test_data:

--- a/tests/gcp_hub_client_test.py
+++ b/tests/gcp_hub_client_test.py
@@ -20,7 +20,6 @@ from absl.testing import parameterized
 
 from googleclouddebugger import gcp_hub_client
 
-
 TEST_DEBUGGEE_ID = 'gcp:debuggee-id'
 TEST_AGENT_ID = 'abc-123-d4'
 TEST_PROJECT_ID = 'test-project-id'
@@ -51,9 +50,10 @@ class GcpHubClientTest(parameterized.TestCase):
 
     self._client = gcp_hub_client.GcpHubClient()
 
-    for backoff in [self._client.register_backoff,
-                    self._client.list_backoff,
-                    self._client.update_backoff]:
+    for backoff in [
+        self._client.register_backoff, self._client.list_backoff,
+        self._client.update_backoff
+    ]:
       backoff.min_interval_sec /= 100000.0
       backoff.max_interval_sec /= 100000.0
       backoff._current_interval_sec /= 100000.0
@@ -252,24 +252,25 @@ class GcpHubClientTest(parameterized.TestCase):
   def _TestInitializeLabels(self, module_var, version_var, minor_var):
     self._Start()
 
-    self._client.InitializeDebuggeeLabels(
-        {'module': 'my_module',
-         'version': '1',
-         'minorversion': '23',
-         'something_else': 'irrelevant'})
+    self._client.InitializeDebuggeeLabels({
+        'module': 'my_module',
+        'version': '1',
+        'minorversion': '23',
+        'something_else': 'irrelevant'
+    })
     self.assertEqual(
-        {'projectid': 'test-project-id',
-         'module': 'my_module',
-         'version': '1',
-         'minorversion': '23',
-         'platform': 'default'},
-        self._client._debuggee_labels)
-    self.assertEqual(
-        'test-project-id-my_module-1',
-        self._client._GetDebuggeeDescription())
+        {
+            'projectid': 'test-project-id',
+            'module': 'my_module',
+            'version': '1',
+            'minorversion': '23',
+            'platform': 'default'
+        }, self._client._debuggee_labels)
+    self.assertEqual('test-project-id-my_module-1',
+                     self._client._GetDebuggeeDescription())
 
-    uniquifier1 = self._client._ComputeUniquifier({
-        'labels': self._client._debuggee_labels})
+    uniquifier1 = self._client._ComputeUniquifier(
+        {'labels': self._client._debuggee_labels})
     self.assertTrue(uniquifier1)  # Not empty string.
 
     try:
@@ -278,29 +279,29 @@ class GcpHubClientTest(parameterized.TestCase):
       os.environ[minor_var] = '3476734'
       self._client.InitializeDebuggeeLabels(None)
       self.assertEqual(
-          {'projectid': 'test-project-id',
-           'module': 'env_module',
-           'version': '213',
-           'minorversion': '3476734',
-           'platform': 'default'},
-          self._client._debuggee_labels)
-      self.assertEqual(
-          'test-project-id-env_module-213',
-          self._client._GetDebuggeeDescription())
+          {
+              'projectid': 'test-project-id',
+              'module': 'env_module',
+              'version': '213',
+              'minorversion': '3476734',
+              'platform': 'default'
+          }, self._client._debuggee_labels)
+      self.assertEqual('test-project-id-env_module-213',
+                       self._client._GetDebuggeeDescription())
 
       os.environ[module_var] = 'default'
       os.environ[version_var] = '213'
       os.environ[minor_var] = '3476734'
       self._client.InitializeDebuggeeLabels({'minorversion': 'something else'})
       self.assertEqual(
-          {'projectid': 'test-project-id',
-           'version': '213',
-           'minorversion': 'something else',
-           'platform': 'default'},
-          self._client._debuggee_labels)
-      self.assertEqual(
-          'test-project-id-213',
-          self._client._GetDebuggeeDescription())
+          {
+              'projectid': 'test-project-id',
+              'version': '213',
+              'minorversion': 'something else',
+              'platform': 'default'
+          }, self._client._debuggee_labels)
+      self.assertEqual('test-project-id-213',
+                       self._client._GetDebuggeeDescription())
 
     finally:
       del os.environ[module_var]
@@ -308,12 +309,12 @@ class GcpHubClientTest(parameterized.TestCase):
       del os.environ[minor_var]
 
   def testInitializeLegacyDebuggeeLabels(self):
-    self._TestInitializeLabels(
-        'GAE_MODULE_NAME', 'GAE_MODULE_VERSION', 'GAE_MINOR_VERSION')
+    self._TestInitializeLabels('GAE_MODULE_NAME', 'GAE_MODULE_VERSION',
+                               'GAE_MINOR_VERSION')
 
   def testInitializeDebuggeeLabels(self):
-    self._TestInitializeLabels(
-        'GAE_SERVICE', 'GAE_VERSION', 'GAE_DEPLOYMENT_ID')
+    self._TestInitializeLabels('GAE_SERVICE', 'GAE_VERSION',
+                               'GAE_DEPLOYMENT_ID')
 
   def testInitializeCloudRunDebuggeeLabels(self):
     self._Start()
@@ -322,12 +323,13 @@ class GcpHubClientTest(parameterized.TestCase):
       os.environ['K_SERVICE'] = 'env_module'
       os.environ['K_REVISION'] = '213'
       self._client.InitializeDebuggeeLabels(None)
-      self.assertEqual({
-          'projectid': 'test-project-id',
-          'module': 'env_module',
-          'version': '213',
-          'platform': 'default'
-      }, self._client._debuggee_labels)
+      self.assertEqual(
+          {
+              'projectid': 'test-project-id',
+              'module': 'env_module',
+              'version': '213',
+              'platform': 'default'
+          }, self._client._debuggee_labels)
       self.assertEqual('test-project-id-env_module-213',
                        self._client._GetDebuggeeDescription())
 
@@ -342,12 +344,13 @@ class GcpHubClientTest(parameterized.TestCase):
       os.environ['FUNCTION_NAME'] = 'fcn-name'
       os.environ['X_GOOGLE_FUNCTION_VERSION'] = '213'
       self._client.InitializeDebuggeeLabels(None)
-      self.assertEqual({
-          'projectid': 'test-project-id',
-          'module': 'fcn-name',
-          'version': '213',
-          'platform': 'cloud_function'
-      }, self._client._debuggee_labels)
+      self.assertEqual(
+          {
+              'projectid': 'test-project-id',
+              'module': 'fcn-name',
+              'version': '213',
+              'platform': 'cloud_function'
+          }, self._client._debuggee_labels)
       self.assertEqual('test-project-id-fcn-name-213',
                        self._client._GetDebuggeeDescription())
 
@@ -361,12 +364,13 @@ class GcpHubClientTest(parameterized.TestCase):
     try:
       os.environ['FUNCTION_NAME'] = 'fcn-name'
       self._client.InitializeDebuggeeLabels(None)
-      self.assertEqual({
-          'projectid': 'test-project-id',
-          'module': 'fcn-name',
-          'version': 'unversioned',
-          'platform': 'cloud_function'
-      }, self._client._debuggee_labels)
+      self.assertEqual(
+          {
+              'projectid': 'test-project-id',
+              'module': 'fcn-name',
+              'version': 'unversioned',
+              'platform': 'cloud_function'
+          }, self._client._debuggee_labels)
       self.assertEqual('test-project-id-fcn-name-unversioned',
                        self._client._GetDebuggeeDescription())
 
@@ -380,13 +384,14 @@ class GcpHubClientTest(parameterized.TestCase):
       os.environ['FUNCTION_NAME'] = 'fcn-name'
       os.environ['FUNCTION_REGION'] = 'fcn-region'
       self._client.InitializeDebuggeeLabels(None)
-      self.assertEqual({
-          'projectid': 'test-project-id',
-          'module': 'fcn-name',
-          'version': 'unversioned',
-          'platform': 'cloud_function',
-          'region': 'fcn-region'
-      }, self._client._debuggee_labels)
+      self.assertEqual(
+          {
+              'projectid': 'test-project-id',
+              'module': 'fcn-name',
+              'version': 'unversioned',
+              'platform': 'cloud_function',
+              'region': 'fcn-region'
+          }, self._client._debuggee_labels)
       self.assertEqual('test-project-id-fcn-name-unversioned',
                        self._client._GetDebuggeeDescription())
 
@@ -461,8 +466,9 @@ class GcpHubClientTest(parameterized.TestCase):
 
     self.assertNotIn('sourceContexts', debuggee_no_source_context1)
     self.assertNotIn('sourceContexts', debuggee_bad_source_context)
-    self.assertListEqual([{'what': 'source context'}],
-                         debuggee_with_source_context['sourceContexts'])
+    self.assertListEqual([{
+        'what': 'source context'
+    }], debuggee_with_source_context['sourceContexts'])
 
     uniquifiers = set()
     uniquifiers.add(debuggee_no_source_context1['uniquifier'])

--- a/tests/glob_data_visibility_policy_test.py
+++ b/tests/glob_data_visibility_policy_test.py
@@ -19,10 +19,7 @@ class GlobDataVisibilityPolicyTest(absltest.TestCase):
         '*.private2',
         '',
     )
-    whitelist_patterns = (
-        'wl1.*',
-        'wl2.*'
-    )
+    whitelist_patterns = ('wl1.*', 'wl2.*')
 
     policy = glob_data_visibility_policy.GlobDataVisibilityPolicy(
         blacklist_patterns, whitelist_patterns)

--- a/tests/imphook2_test.py
+++ b/tests/imphook2_test.py
@@ -52,10 +52,8 @@ class ImportHookTest2(absltest.TestCase):
     self._Hook(self._CreateFile('testpkg4/__init__.py'))
     import testpkg4  # pylint: disable=g-import-not-at-top,unused-variable
     import testpkg4  # pylint: disable=g-import-not-at-top,unused-variable
-    self.assertEqual(
-        ['testpkg4/__init__.py',
-         'testpkg4/__init__.py'],
-        sorted(self._import_callbacks_log))
+    self.assertEqual(['testpkg4/__init__.py', 'testpkg4/__init__.py'],
+                     sorted(self._import_callbacks_log))
 
   def testRemoveCallback(self):
     cleanup = self._Hook(self._CreateFile('testpkg4b/__init__.py'))
@@ -77,19 +75,15 @@ class ImportHookTest2(absltest.TestCase):
     self._Hook(self._CreateFile('testpkg6/third.py'))
     import testpkg6.first  # pylint: disable=g-import-not-at-top,unused-variable
     self.assertEqual(
-        ['testpkg6/first.py',
-         'testpkg6/second.py',
-         'testpkg6/third.py'],
+        ['testpkg6/first.py', 'testpkg6/second.py', 'testpkg6/third.py'],
         sorted(self._import_callbacks_log))
 
   def testPackageDotModuleImport(self):
     self._Hook(self._CreateFile('testpkg8/__init__.py'))
     self._Hook(self._CreateFile('testpkg8/my.py'))
     import testpkg8.my  # pylint: disable=g-import-not-at-top,unused-variable
-    self.assertEqual(
-        ['testpkg8/__init__.py',
-         'testpkg8/my.py'],
-        sorted(self._import_callbacks_log))
+    self.assertEqual(['testpkg8/__init__.py', 'testpkg8/my.py'],
+                     sorted(self._import_callbacks_log))
 
   def testNestedPackageDotModuleImport(self):
     self._Hook(self._CreateFile('testpkg9a/__init__.py'))
@@ -97,8 +91,7 @@ class ImportHookTest2(absltest.TestCase):
     self._CreateFile('testpkg9a/testpkg9b/my.py')
     import testpkg9a.testpkg9b.my  # pylint: disable=g-import-not-at-top,unused-variable
     self.assertEqual(
-        ['testpkg9a/__init__.py',
-         'testpkg9a/testpkg9b/__init__.py'],
+        ['testpkg9a/__init__.py', 'testpkg9a/testpkg9b/__init__.py'],
         sorted(self._import_callbacks_log))
 
   def testFromImport(self):
@@ -109,15 +102,12 @@ class ImportHookTest2(absltest.TestCase):
 
   def testTransitiveFromImport(self):
     self._CreateFile('testpkg7/__init__.py')
-    self._Hook(self._CreateFile(
-        'testpkg7/first.py',
-        'from testpkg7 import second'))
+    self._Hook(
+        self._CreateFile('testpkg7/first.py', 'from testpkg7 import second'))
     self._Hook(self._CreateFile('testpkg7/second.py'))
     from testpkg7 import first  # pylint: disable=g-import-not-at-top,unused-variable
-    self.assertEqual(
-        ['testpkg7/first.py',
-         'testpkg7/second.py'],
-        sorted(self._import_callbacks_log))
+    self.assertEqual(['testpkg7/first.py', 'testpkg7/second.py'],
+                     sorted(self._import_callbacks_log))
 
   def testFromNestedPackageImportModule(self):
     self._Hook(self._CreateFile('testpkg11a/__init__.py'))
@@ -125,12 +115,10 @@ class ImportHookTest2(absltest.TestCase):
     self._Hook(self._CreateFile('testpkg11a/testpkg11b/my.py'))
     self._Hook(self._CreateFile('testpkg11a/testpkg11b/your.py'))
     from testpkg11a.testpkg11b import my, your  # pylint: disable=g-import-not-at-top,unused-variable,g-multiple-import
-    self.assertEqual(
-        ['testpkg11a/__init__.py',
-         'testpkg11a/testpkg11b/__init__.py',
-         'testpkg11a/testpkg11b/my.py',
-         'testpkg11a/testpkg11b/your.py'],
-        sorted(self._import_callbacks_log))
+    self.assertEqual([
+        'testpkg11a/__init__.py', 'testpkg11a/testpkg11b/__init__.py',
+        'testpkg11a/testpkg11b/my.py', 'testpkg11a/testpkg11b/your.py'
+    ], sorted(self._import_callbacks_log))
 
   def testDoubleNestedImport(self):
     self._Hook(self._CreateFile('testpkg12a/__init__.py'))
@@ -138,14 +126,12 @@ class ImportHookTest2(absltest.TestCase):
     self._Hook(self._CreateFile('testpkg12a/testpkg12b/my.py'))
     from testpkg12a.testpkg12b import my  # pylint: disable=g-import-not-at-top,unused-variable,g-multiple-import
     from testpkg12a.testpkg12b import my  # pylint: disable=g-import-not-at-top,unused-variable,g-multiple-import
-    self.assertEqual(
-        ['testpkg12a/__init__.py',
-         'testpkg12a/__init__.py',
-         'testpkg12a/testpkg12b/__init__.py',
-         'testpkg12a/testpkg12b/__init__.py',
-         'testpkg12a/testpkg12b/my.py',
-         'testpkg12a/testpkg12b/my.py'],
-        sorted(self._import_callbacks_log))
+    self.assertEqual([
+        'testpkg12a/__init__.py', 'testpkg12a/__init__.py',
+        'testpkg12a/testpkg12b/__init__.py',
+        'testpkg12a/testpkg12b/__init__.py', 'testpkg12a/testpkg12b/my.py',
+        'testpkg12a/testpkg12b/my.py'
+    ], sorted(self._import_callbacks_log))
 
   def testFromPackageImportStar(self):
     self._Hook(self._CreateFile('testpkg13a/__init__.py'))
@@ -161,10 +147,8 @@ class ImportHookTest2(absltest.TestCase):
     self._Hook(self._CreateFile('testpkg14a/my1.py'))
     self._Hook(self._CreateFile('testpkg14a/your1.py'))
     exec('from testpkg14a import *')  # pylint: disable=exec-used
-    self.assertEqual(
-        ['testpkg14a/__init__.py',
-         'testpkg14a/my1.py'],
-        sorted(self._import_callbacks_log))
+    self.assertEqual(['testpkg14a/__init__.py', 'testpkg14a/my1.py'],
+                     sorted(self._import_callbacks_log))
 
   def testImportFunction(self):
     self._Hook(self._CreateFile('testpkg27/__init__.py'))
@@ -175,9 +159,9 @@ class ImportHookTest2(absltest.TestCase):
     self._Hook(self._CreateFile('zero.py'))
     self._Hook(self._CreateFile('testpkg15a/__init__.py'))
     self._Hook(self._CreateFile('testpkg15a/first.py'))
-    self._Hook(self._CreateFile(
-        'testpkg15a/testpkg15b/__init__.py',
-        'assert False, "unexpected import"'))
+    self._Hook(
+        self._CreateFile('testpkg15a/testpkg15b/__init__.py',
+                         'assert False, "unexpected import"'))
     self._Hook(self._CreateFile('testpkg15a/testpkg15c/__init__.py'))
     self._Hook(self._CreateFile('testpkg15a/testpkg15c/second.py'))
 
@@ -193,18 +177,14 @@ class ImportHookTest2(absltest.TestCase):
 
     # Import package.module.
     importlib.import_module('testpkg15a.first')
-    self.assertEqual(
-        ['testpkg15a/__init__.py',
-         'testpkg15a/first.py'],
-        sorted(self._import_callbacks_log))
+    self.assertEqual(['testpkg15a/__init__.py', 'testpkg15a/first.py'],
+                     sorted(self._import_callbacks_log))
     self._import_callbacks_log = []
 
     # Relative module import from package context.
     importlib.import_module('.first', 'testpkg15a')
-    self.assertEqual(
-        ['testpkg15a/__init__.py',
-         'testpkg15a/first.py'],
-        sorted(self._import_callbacks_log))
+    self.assertEqual(['testpkg15a/__init__.py', 'testpkg15a/first.py'],
+                     sorted(self._import_callbacks_log))
     self._import_callbacks_log = []
 
     # Relative module import from package context with '..'.
@@ -216,31 +196,32 @@ class ImportHookTest2(absltest.TestCase):
     else:
       importlib.import_module('..first', 'testpkg15a.testpkg15b')
     self.assertEqual(
-        ['testpkg15a/__init__.py',
-         # TODO: Importlib may or may not load testpkg15b,
-         # depending on the implementation. Currently on blaze, it does not
-         # load testpkg15b, but a similar non-blaze code on my workstation
-         # loads testpkg15b. We should verify this behavior.
-         # 'testpkg15a/testpkg15b/__init__.py',
-         'testpkg15a/first.py'],
+        [
+            'testpkg15a/__init__.py',
+            # TODO: Importlib may or may not load testpkg15b,
+            # depending on the implementation. Currently on blaze, it does not
+            # load testpkg15b, but a similar non-blaze code on my workstation
+            # loads testpkg15b. We should verify this behavior.
+            # 'testpkg15a/testpkg15b/__init__.py',
+            'testpkg15a/first.py'
+        ],
         sorted(self._import_callbacks_log))
     self._import_callbacks_log = []
 
     # Relative module import from nested package context.
     importlib.import_module('.second', 'testpkg15a.testpkg15c')
-    self.assertEqual(
-        ['testpkg15a/__init__.py',
-         'testpkg15a/testpkg15c/__init__.py',
-         'testpkg15a/testpkg15c/second.py'],
-        sorted(self._import_callbacks_log))
+    self.assertEqual([
+        'testpkg15a/__init__.py', 'testpkg15a/testpkg15c/__init__.py',
+        'testpkg15a/testpkg15c/second.py'
+    ], sorted(self._import_callbacks_log))
     self._import_callbacks_log = []
 
   def testRemoveImportHookFromCallback(self):
+
     def RunCleanup(unused_mod):
       cleanup()
 
-    cleanup = self._Hook(
-        self._CreateFile('testpkg15/__init__.py'), RunCleanup)
+    cleanup = self._Hook(self._CreateFile('testpkg15/__init__.py'), RunCleanup)
     import testpkg15  # pylint: disable=g-import-not-at-top,unused-variable
     import testpkg15  # pylint: disable=g-import-not-at-top,unused-variable
     import testpkg15  # pylint: disable=g-import-not-at-top,unused-variable
@@ -255,14 +236,13 @@ class ImportHookTest2(absltest.TestCase):
       self.assertEqual(1, getattr(module, 'validate', None), 'premature call')
 
     self._Hook(self._CreateFile('testpkg16/my1.py'))
-    self._Hook(self._CreateFile('testpkg16/__init__.py',
-                                'import my1\nvalidate = 1'), CheckFullyLoaded)
+    self._Hook(
+        self._CreateFile('testpkg16/__init__.py', 'import my1\nvalidate = 1'),
+        CheckFullyLoaded)
     import testpkg16.my1  # pylint: disable=g-import-not-at-top,unused-variable
 
-    self.assertEqual(
-        ['testpkg16/__init__.py',
-         'testpkg16/my1.py'],
-        sorted(self._import_callbacks_log))
+    self.assertEqual(['testpkg16/__init__.py', 'testpkg16/my1.py'],
+                     sorted(self._import_callbacks_log))
 
   def testCircularImportNoPrematureCallback(self):
     # Verifies that the callback is not invoked before the first module is fully
@@ -272,22 +252,16 @@ class ImportHookTest2(absltest.TestCase):
 
     self._CreateFile('testpkg17/__init__.py')
     self._Hook(
-        self._CreateFile(
-            'testpkg17/c1.py',
-            'import testpkg17.c2\nvalidate = 1', False),
-        CheckFullyLoaded)
+        self._CreateFile('testpkg17/c1.py', 'import testpkg17.c2\nvalidate = 1',
+                         False), CheckFullyLoaded)
     self._Hook(
-        self._CreateFile(
-            'testpkg17/c2.py',
-            'import testpkg17.c1\nvalidate = 1', False),
-        CheckFullyLoaded)
+        self._CreateFile('testpkg17/c2.py', 'import testpkg17.c1\nvalidate = 1',
+                         False), CheckFullyLoaded)
 
     import testpkg17.c1  # pylint: disable=g-import-not-at-top,unused-variable
 
-    self.assertEqual(
-        ['testpkg17/c1.py',
-         'testpkg17/c2.py'],
-        sorted(self._import_callbacks_log))
+    self.assertEqual(['testpkg17/c1.py', 'testpkg17/c2.py'],
+                     sorted(self._import_callbacks_log))
 
   def testImportException(self):
     # An exception is thrown by the builtin importer during import.
@@ -307,8 +281,9 @@ class ImportHookTest2(absltest.TestCase):
   def testImportNestedException(self):
     # An import exception is thrown and caught inside a module being imported.
     self._CreateFile('testpkg19/__init__.py')
-    self._Hook(self._CreateFile('testpkg19/m19.py',
-                                'try: import m19b\nexcept ImportError: pass'))
+    self._Hook(
+        self._CreateFile('testpkg19/m19.py',
+                         'try: import m19b\nexcept ImportError: pass'))
 
     import testpkg19.m19  # pylint: disable=g-import-not-at-top,unused-variable
 
@@ -343,13 +318,11 @@ class ImportHookTest2(absltest.TestCase):
   def testFromImportImportsFunction(self):
     self._CreateFile('testpkg21a/__init__.py')
     self._CreateFile('testpkg21a/testpkg21b/__init__.py')
-    self._CreateFile(
-        'testpkg21a/testpkg21b/mod.py',
-        ('def func1():\n'
-         '  return 5\n'
-         '\n'
-         'def func2():\n'
-         '  return 7\n'))
+    self._CreateFile('testpkg21a/testpkg21b/mod.py', ('def func1():\n'
+                                                      '  return 5\n'
+                                                      '\n'
+                                                      'def func2():\n'
+                                                      '  return 7\n'))
 
     self._Hook('mod.py')
     from testpkg21a.testpkg21b.mod import func1, func2  # pylint: disable=g-import-not-at-top,unused-variable,g-multiple-import
@@ -357,9 +330,7 @@ class ImportHookTest2(absltest.TestCase):
 
   def testImportSibling(self):
     self._CreateFile('testpkg22/__init__.py')
-    self._CreateFile(
-        'testpkg22/first.py',
-        'import second')
+    self._CreateFile('testpkg22/first.py', 'import second')
     self._CreateFile('testpkg22/second.py')
 
     self._Hook('testpkg22/second.py')
@@ -376,22 +347,20 @@ class ImportHookTest2(absltest.TestCase):
 
     self._Hook('testpkg23/testpkg23/second.py')
     import testpkg23.first  # pylint: disable=g-import-not-at-top,unused-variable
-    self.assertEqual(
-        ['testpkg23/testpkg23/second.py'],
-        self._import_callbacks_log)
+    self.assertEqual(['testpkg23/testpkg23/second.py'],
+                     self._import_callbacks_log)
 
   def testImportSiblingFromInit(self):
     self._Hook(self._CreateFile('testpkg23a/__init__.py', 'import testpkg23b'))
-    self._Hook(self._CreateFile(
-        'testpkg23a/testpkg23b/__init__.py',
-        'import testpkg23c'))
+    self._Hook(
+        self._CreateFile('testpkg23a/testpkg23b/__init__.py',
+                         'import testpkg23c'))
     self._Hook(self._CreateFile('testpkg23a/testpkg23b/testpkg23c/__init__.py'))
     import testpkg23a  # pylint: disable=g-import-not-at-top,unused-variable
-    self.assertEqual(
-        ['testpkg23a/__init__.py',
-         'testpkg23a/testpkg23b/__init__.py',
-         'testpkg23a/testpkg23b/testpkg23c/__init__.py'],
-        sorted(self._import_callbacks_log))
+    self.assertEqual([
+        'testpkg23a/__init__.py', 'testpkg23a/testpkg23b/__init__.py',
+        'testpkg23a/testpkg23b/testpkg23c/__init__.py'
+    ], sorted(self._import_callbacks_log))
 
   def testThreadLocalCleanup(self):
     self._CreateFile('testpkg24/__init__.py')
@@ -411,11 +380,10 @@ class ImportHookTest2(absltest.TestCase):
     self._CreateFile(
         'testpkg25/foo.py',
         'import bar\n'  # success.
-        'import baz')   # success.
+        'import baz')  # success.
     self._CreateFile('testpkg25/bar.py')
     self._CreateFile(
-        'testpkg25/baz.py',
-        'try:\n'
+        'testpkg25/baz.py', 'try:\n'
         '  import testpkg25b\n'
         'except ImportError:\n'
         '  pass')
@@ -434,7 +402,7 @@ class ImportHookTest2(absltest.TestCase):
     self._CreateFile(
         'testpkg26/foo.py',
         'import bar\n'  # success.
-        'import baz')   # fail.
+        'import baz')  # fail.
     self._CreateFile('testpkg26/bar.py')
 
     # Create a hook for any arbitrary module. Doesn't need to hit.
@@ -510,8 +478,8 @@ class ImportHookTest2(absltest.TestCase):
   # TODO: add test for the module param in the callback.
   def _Hook(self, path, callback=lambda m: None):
     cleanup = imphook2.AddImportCallbackBySuffix(
-        path,
-        lambda mod: (self._import_callbacks_log.append(path), callback(mod)))
+        path, lambda mod:
+        (self._import_callbacks_log.append(path), callback(mod)))
     self.assertTrue(cleanup, path)
     self._callback_cleanups.append(cleanup)
     return cleanup

--- a/tests/module_explorer_test_disabled.py
+++ b/tests/module_explorer_test_disabled.py
@@ -64,15 +64,24 @@ class ModuleExplorerTest(absltest.TestCase):
 
   def testDeepInnerMethod(self):
     """Verify that inner of inner of inner, etc. method is found."""
+
     def Inner1():
+
       def Inner2():
+
         def Inner3():
+
           def Inner4():
+
             def Inner5():
               pass
+
             return six.get_function_code(Inner5)
+
           return Inner4()
+
         return Inner3()
+
       return Inner2()
 
     self.assertIn(Inner1(), self._code_objects)
@@ -118,8 +127,8 @@ class ModuleExplorerTest(absltest.TestCase):
     self.assertEqual('GlobalMethodWithClosureDecorator', co.co_name)
 
   def testClassMethodWithClosureDecorator(self):
-    co = self._GetCodeObjectAtLine(self._module,
-                                   'GLOBAL_CLASS_METHOD_WITH_CLOSURE_DECORATOR')
+    co = self._GetCodeObjectAtLine(
+        self._module, 'GLOBAL_CLASS_METHOD_WITH_CLOSURE_DECORATOR')
     self.assertTrue(co)
     self.assertEqual('FnWithClosureDecorator', co.co_name)
 
@@ -145,16 +154,15 @@ class ModuleExplorerTest(absltest.TestCase):
 
   def testCodeObjectAtLine(self):
     """Verify that query of code object at a specified source line."""
-    test_cases = [
-        (six.get_function_code(self.testCodeObjectAtLine),
-         'TEST_CODE_OBJECT_AT_ASSERT'),
-        (ModuleExplorerTest._StaticMethod(), 'INNER_OF_STATIC_METHOD'),
-        (_GlobalMethod(), 'INNER_OF_GLOBAL_METHOD')]
+    test_cases = [(six.get_function_code(self.testCodeObjectAtLine),
+                   'TEST_CODE_OBJECT_AT_ASSERT'),
+                  (ModuleExplorerTest._StaticMethod(),
+                   'INNER_OF_STATIC_METHOD'),
+                  (_GlobalMethod(), 'INNER_OF_GLOBAL_METHOD')]
 
     for code_object, tag in test_cases:
       self.assertEqual(  # BPTAG: TEST_CODE_OBJECT_AT_ASSERT
-          code_object,
-          self._GetCodeObjectAtLine(code_object, tag))
+          code_object, self._GetCodeObjectAtLine(code_object, tag))
 
   def testCodeObjectWithoutModule(self):
     """Verify no crash/hang when module has no file name."""
@@ -163,6 +171,7 @@ class ModuleExplorerTest(absltest.TestCase):
 
     self.assertFalse(
         module_explorer.GetCodeObjectAtLine(self._module, 111111)[0])
+
 
 # TODO: Re-enable this test, without hardcoding a python version into it.
 #  def testCodeExtensionMismatch(self):
@@ -217,6 +226,7 @@ class ModuleExplorerTest(absltest.TestCase):
       module_explorer._MAX_REFERENTS_BFS_DEPTH = default_quota
 
   def testMaxObjectReferents(self):
+
     class A(object):
       pass
 
@@ -249,6 +259,7 @@ class ModuleExplorerTest(absltest.TestCase):
 
   @staticmethod
   def _StaticMethod():
+
     def InnerMethod():
       pass  # BPTAG: INNER_OF_STATIC_METHOD
 
@@ -261,6 +272,7 @@ class ModuleExplorerTest(absltest.TestCase):
 
 
 def _GlobalMethod():
+
   def InnerMethod():
     pass  # BPTAG: INNER_OF_GLOBAL_METHOD
 
@@ -268,6 +280,7 @@ def _GlobalMethod():
 
 
 def ClosureDecorator(handler):
+
   def Caller(*args):
     return handler(*args)
 
@@ -310,6 +323,7 @@ def _MethodWithLambdaExpression():
 
 def _MethodWithGeneratorExpression():
   return (i for i in range(0, 2)).gi_code
+
 
 # Used for testMaxObjectReferents, need to be in global scope or else the module
 # explorer would not explore this

--- a/tests/module_search2_test.py
+++ b/tests/module_search2_test.py
@@ -23,8 +23,7 @@ class SearchModulesTest(absltest.TestCase):
   def testSearchValidSourcePath(self):
     # These modules are on the sys.path.
     self.assertEndsWith(
-        module_search2.Search(
-            'googleclouddebugger/module_search2.py'),
+        module_search2.Search('googleclouddebugger/module_search2.py'),
         '/site-packages/googleclouddebugger/module_search2.py')
 
     # inspect and dis are <embedded stdlib> libraries with no real file. So, we
@@ -36,9 +35,7 @@ class SearchModulesTest(absltest.TestCase):
 
     # This module exists, but the search input is missing the outer package
     # name.
-    self.assertEqual(
-        module_search2.Search('absltest.py'),
-        'absltest.py')
+    self.assertEqual(module_search2.Search('absltest.py'), 'absltest.py')
 
   def testSearchInvalidExtension(self):
     # Test that the module rejects invalid extension in the input.
@@ -87,8 +84,7 @@ class SearchModulesTest(absltest.TestCase):
       # Returned result should have a successful file match and symbolic
       # links should be kept.
       self.assertEndsWith(
-          module_search2.Search('b/first.py'),
-          'link/b/first.py')
+          module_search2.Search('b/first.py'), 'link/b/first.py')
     finally:
       sys.path.remove(os.path.join(self._test_package_dir, 'link'))
 

--- a/tests/module_utils2_test.py
+++ b/tests/module_utils2_test.py
@@ -59,13 +59,9 @@ class ModuleUtilsTest(absltest.TestCase):
     # Lookup simple module.
     _AddSysModule('m1', '/a/b/p1/m1.pyc')
     for suffix in [
-        'm1.py',
-        'm1.pyc',
-        'm1.pyo',
-        'p1/m1.py',
-        'b/p1/m1.py',
-        'a/b/p1/m1.py',
-        '/a/b/p1/m1.py']:
+        'm1.py', 'm1.pyc', 'm1.pyo', 'p1/m1.py', 'b/p1/m1.py', 'a/b/p1/m1.py',
+        '/a/b/p1/m1.py'
+    ]:
       m1 = module_utils2.GetLoadedModuleBySuffix(suffix)
       self.assertTrue(m1, 'Module not found')
       self.assertEqual('/a/b/p1/m1.pyc', m1.__file__)
@@ -73,21 +69,17 @@ class ModuleUtilsTest(absltest.TestCase):
     # Lookup simple package, no ext.
     _AddSysModule('p1', '/a/b/p1/__init__.pyc')
     for suffix in [
-        'p1/__init__.py',
-        'b/p1/__init__.py',
-        'a/b/p1/__init__.py',
-        '/a/b/p1/__init__.py']:
+        'p1/__init__.py', 'b/p1/__init__.py', 'a/b/p1/__init__.py',
+        '/a/b/p1/__init__.py'
+    ]:
       p1 = module_utils2.GetLoadedModuleBySuffix(suffix)
       self.assertTrue(p1, 'Package not found')
       self.assertEqual('/a/b/p1/__init__.pyc', p1.__file__)
 
     # Lookup via bad suffix.
     for suffix in [
-        'm2.py',
-        'p2/m1.py',
-        'b2/p1/m1.py',
-        'a2/b/p1/m1.py',
-        '/a2/b/p1/m1.py']:
+        'm2.py', 'p2/m1.py', 'b2/p1/m1.py', 'a2/b/p1/m1.py', '/a2/b/p1/m1.py'
+    ]:
       m1 = module_utils2.GetLoadedModuleBySuffix(suffix)
       self.assertFalse(m1, 'Module found unexpectedly')
 
@@ -95,11 +87,8 @@ class ModuleUtilsTest(absltest.TestCase):
     # Lookup complex module.
     _AddSysModule('b.p1.m1', '/a/b/p1/m1.pyc')
     for suffix in [
-        'm1.py',
-        'p1/m1.py',
-        'b/p1/m1.py',
-        'a/b/p1/m1.py',
-        '/a/b/p1/m1.py']:
+        'm1.py', 'p1/m1.py', 'b/p1/m1.py', 'a/b/p1/m1.py', '/a/b/p1/m1.py'
+    ]:
       m1 = module_utils2.GetLoadedModuleBySuffix(suffix)
       self.assertTrue(m1, 'Module not found')
       self.assertEqual('/a/b/p1/m1.pyc', m1.__file__)
@@ -107,10 +96,9 @@ class ModuleUtilsTest(absltest.TestCase):
     # Lookup complex package, no ext.
     _AddSysModule('a.b.p1', '/a/b/p1/__init__.pyc')
     for suffix in [
-        'p1/__init__.py',
-        'b/p1/__init__.py',
-        'a/b/p1/__init__.py',
-        '/a/b/p1/__init__.py']:
+        'p1/__init__.py', 'b/p1/__init__.py', 'a/b/p1/__init__.py',
+        '/a/b/p1/__init__.py'
+    ]:
       p1 = module_utils2.GetLoadedModuleBySuffix(suffix)
       self.assertTrue(p1, 'Package not found')
       self.assertEqual('/a/b/p1/__init__.pyc', p1.__file__)
@@ -144,16 +132,12 @@ class ModuleUtilsTest(absltest.TestCase):
     # Ambiguous request, multiple modules might have matched.
     m1 = module_utils2.GetLoadedModuleBySuffix('/m1/__init__.py')
     self.assertTrue(m1, 'Package not found')
-    self.assertIn(
-        m1.__file__,
-        ['/m1/__init__.pyc', '/m1/m1/m1/__init__.pyc'])
+    self.assertIn(m1.__file__, ['/m1/__init__.pyc', '/m1/m1/m1/__init__.pyc'])
 
     # Ambiguous request, multiple modules might have matched.
     m1m1 = module_utils2.GetLoadedModuleBySuffix('/m1/m1.py')
     self.assertTrue(m1m1, 'Module not found')
-    self.assertIn(
-        m1m1.__file__,
-        ['/m1/m1.pyc', '/m1/m1/m1/m1.pyc'])
+    self.assertIn(m1m1.__file__, ['/m1/m1.pyc', '/m1/m1/m1/m1.pyc'])
 
     # Not ambiguous. Only 1 match possible.
     m1m1m1 = module_utils2.GetLoadedModuleBySuffix('/m1/m1/m1/__init__.py')

--- a/tests/native_module_test.py
+++ b/tests/native_module_test.py
@@ -44,6 +44,7 @@ class NativeModuleTest(absltest.TestCase):
     self._ClearAllBreakpoints()
 
   def testUnconditionalBreakpoint(self):
+
     def Trigger():
       unused_lock = threading.Lock()
       print('Breakpoint trigger')  # BPTAG: UNCONDITIONAL_BREAKPOINT
@@ -53,6 +54,7 @@ class NativeModuleTest(absltest.TestCase):
     self.assertEqual(1, self._breakpoint_counter)
 
   def testConditionalBreakpoint(self):
+
     def Trigger():
       d = {}
       for i in range(1, 10):
@@ -75,6 +77,7 @@ class NativeModuleTest(absltest.TestCase):
     self.assertEqual(1, self._breakpoint_counter)
 
   def testMissingModule(self):
+
     def Test():
       native.CreateConditionalBreakpoint(None, 123123, None,
                                          self._BreakpointEvent)
@@ -82,6 +85,7 @@ class NativeModuleTest(absltest.TestCase):
     self.assertRaises(TypeError, Test)
 
   def testBadModule(self):
+
     def Test():
       native.CreateConditionalBreakpoint('str', 123123, None,
                                          self._BreakpointEvent)
@@ -89,6 +93,7 @@ class NativeModuleTest(absltest.TestCase):
     self.assertRaises(TypeError, Test)
 
   def testInvalidCondition(self):
+
     def Test():
       native.CreateConditionalBreakpoint(sys.modules[__name__], 123123, '2+2',
                                          self._BreakpointEvent)
@@ -96,39 +101,43 @@ class NativeModuleTest(absltest.TestCase):
     self.assertRaises(TypeError, Test)
 
   def testMissingCallback(self):
+
     def Test():
       native.CreateConditionalBreakpoint('code.py', 123123, None, None)
 
     self.assertRaises(TypeError, Test)
 
   def testInvalidCallback(self):
+
     def Test():
       native.CreateConditionalBreakpoint('code.py', 123123, None, {})
 
     self.assertRaises(TypeError, Test)
 
   def testMissingCookie(self):
-    self.assertRaises(
-        TypeError,
-        lambda: native.ClearConditionalBreakpoint(None))
+    self.assertRaises(TypeError,
+                      lambda: native.ClearConditionalBreakpoint(None))
 
   def testInvalidCookie(self):
     native.ClearConditionalBreakpoint(387873457)
 
   def testMutableCondition(self):
+
     def Trigger():
+
       def MutableMethod():
         self._evil = True
         return True
+
       print('MutableMethod = %s' % MutableMethod)  # BPTAG: MUTABLE_CONDITION
 
     self._SetBreakpoint(Trigger, 'MUTABLE_CONDITION', 'MutableMethod()')
     Trigger()
-    self.assertEqual(
-        [native.BREAKPOINT_EVENT_CONDITION_EXPRESSION_MUTABLE],
-        self._PopBreakpointEvents())
+    self.assertEqual([native.BREAKPOINT_EVENT_CONDITION_EXPRESSION_MUTABLE],
+                     self._PopBreakpointEvents())
 
   def testGlobalConditionQuotaExceeded(self):
+
     def Trigger():
       print('Breakpoint trigger')  # BPTAG: GLOBAL_CONDITION_QUOTA
 
@@ -144,6 +153,7 @@ class NativeModuleTest(absltest.TestCase):
     time.sleep(0.1)
 
   def testBreakpointConditionQuotaExceeded(self):
+
     def Trigger():
       print('Breakpoint trigger')  # BPTAG: PER_BREAKPOINT_CONDITION_QUOTA
 
@@ -153,10 +163,8 @@ class NativeModuleTest(absltest.TestCase):
     # increase the complexity of a condition until we hit it.
     base = 100
     while True:
-      self._SetBreakpoint(
-          Trigger,
-          'PER_BREAKPOINT_CONDITION_QUOTA',
-          '_DoHardWork(%d)' % base)
+      self._SetBreakpoint(Trigger, 'PER_BREAKPOINT_CONDITION_QUOTA',
+                          '_DoHardWork(%d)' % base)
       Trigger()
       self._ClearAllBreakpoints()
 
@@ -174,61 +182,54 @@ class NativeModuleTest(absltest.TestCase):
     time.sleep(0.1)
 
   def testImmutableCallSuccess(self):
+
     def Add(a, b, c):
       return a + b + c
 
     def Magic():
       return 'cake'
 
-    self.assertEqual(
-        '643535',
-        self._CallImmutable(inspect.currentframe(), 'str(643535)'))
+    self.assertEqual('643535',
+                     self._CallImmutable(inspect.currentframe(), 'str(643535)'))
     self.assertEqual(
         786 + 23 + 891,
         self._CallImmutable(inspect.currentframe(), 'Add(786, 23, 891)'))
-    self.assertEqual(
-        'cake',
-        self._CallImmutable(inspect.currentframe(), 'Magic()'))
+    self.assertEqual('cake',
+                     self._CallImmutable(inspect.currentframe(), 'Magic()'))
     return Add or Magic
 
   def testImmutableCallMutable(self):
+
     def Change():
       dictionary['bad'] = True
 
     dictionary = {}
     frame = inspect.currentframe()
-    self.assertRaises(
-        SystemError,
-        lambda: self._CallImmutable(frame, 'Change()'))
+    self.assertRaises(SystemError,
+                      lambda: self._CallImmutable(frame, 'Change()'))
     self.assertEqual({}, dictionary)
     return Change
 
   def testImmutableCallExceptionPropagation(self):
+
     def Divide(a, b):
       return a / b
 
     frame = inspect.currentframe()
-    self.assertRaises(
-        ZeroDivisionError,
-        lambda: self._CallImmutable(frame, 'Divide(1, 0)'))
+    self.assertRaises(ZeroDivisionError,
+                      lambda: self._CallImmutable(frame, 'Divide(1, 0)'))
     return Divide
 
   def testImmutableCallInvalidFrame(self):
-    self.assertRaises(
-        TypeError,
-        lambda: native.CallImmutable(None, lambda: 1))
-    self.assertRaises(
-        TypeError,
-        lambda: native.CallImmutable('not a frame', lambda: 1))
+    self.assertRaises(TypeError, lambda: native.CallImmutable(None, lambda: 1))
+    self.assertRaises(TypeError,
+                      lambda: native.CallImmutable('not a frame', lambda: 1))
 
   def testImmutableCallInvalidCallable(self):
     frame = inspect.currentframe()
-    self.assertRaises(
-        TypeError,
-        lambda: native.CallImmutable(frame, None))
-    self.assertRaises(
-        TypeError,
-        lambda: native.CallImmutable(frame, 'not a callable'))
+    self.assertRaises(TypeError, lambda: native.CallImmutable(frame, None))
+    self.assertRaises(TypeError,
+                      lambda: native.CallImmutable(frame, 'not a callable'))
 
   def _SetBreakpoint(self, method, tag, condition=None):
     """Sets a breakpoint in this source file.
@@ -263,9 +264,8 @@ class NativeModuleTest(absltest.TestCase):
 
   def _CallImmutable(self, frame, expression):
     """Wrapper over native.ImmutableCall for callable."""
-    return native.CallImmutable(
-        frame,
-        compile(expression, '<expression>', 'eval'))
+    return native.CallImmutable(frame,
+                                compile(expression, '<expression>', 'eval'))
 
   def _BreakpointEvent(self, event, frame):
     """Callback on breakpoint event.

--- a/tests/python_breakpoint_test_disabled.py
+++ b/tests/python_breakpoint_test_disabled.py
@@ -30,7 +30,11 @@ class PythonBreakpointTest(absltest.TestCase):
     self._template = {
         'id': 'BP_ID',
         'createTime': python_test_util.DateTimeToTimestamp(self._base_time),
-        'location': {'path': path, 'line': line}}
+        'location': {
+            'path': path,
+            'line': line
+        }
+    }
     self._completed = set()
     self._update_queue = []
 
@@ -50,23 +54,20 @@ class PythonBreakpointTest(absltest.TestCase):
     self._update_queue.append(breakpoint)
 
   def testClear(self):
-    breakpoint = python_breakpoint.PythonBreakpoint(
-        self._template, self, self, None)
+    breakpoint = python_breakpoint.PythonBreakpoint(self._template, self, self,
+                                                    None)
     breakpoint.Clear()
     self.assertFalse(breakpoint._cookie)
 
   def testId(self):
-    breakpoint = python_breakpoint.PythonBreakpoint(
-        self._template, self, self, None)
+    breakpoint = python_breakpoint.PythonBreakpoint(self._template, self, self,
+                                                    None)
     breakpoint.Clear()
     self.assertEqual('BP_ID', breakpoint.GetBreakpointId())
 
   def testNullBytesInCondition(self):
     python_breakpoint.PythonBreakpoint(
-        dict(self._template, condition='\0'),
-        self,
-        self,
-        None)
+        dict(self._template, condition='\0'), self, self, None)
     self.assertEqual(set(['BP_ID']), self._completed)
     self.assertLen(self._update_queue, 1)
     self.assertTrue(self._update_queue[0]['status']['isError'])
@@ -83,10 +84,10 @@ class PythonBreakpointTest(absltest.TestCase):
       f.write('  print("Hello from deferred module")\n')
 
     python_breakpoint.PythonBreakpoint(
-        dict(self._template, location={'path': 'defer_print.py', 'line': 2}),
-        self,
-        self,
-        None)
+        dict(self._template, location={
+            'path': 'defer_print.py',
+            'line': 2
+        }), self, self, None)
 
     self.assertFalse(self._completed)
     self.assertEmpty(self._update_queue)
@@ -97,9 +98,8 @@ class PythonBreakpointTest(absltest.TestCase):
     self.assertEqual(set(['BP_ID']), self._completed)
     self.assertLen(self._update_queue, 1)
     self.assertGreater(len(self._update_queue[0]['stackFrames']), 3)
-    self.assertEqual(
-        'DoPrint',
-        self._update_queue[0]['stackFrames'][0]['function'])
+    self.assertEqual('DoPrint',
+                     self._update_queue[0]['stackFrames'][0]['function'])
     self.assertTrue(self._update_queue[0]['isFinalState'])
 
     self.assertEmpty(imphook2._import_callbacks)
@@ -124,26 +124,23 @@ class PythonBreakpointTest(absltest.TestCase):
     # Search will proceed in sys.path order, and the first match in sys.path
     # will uniquely identify the full path of the module as inner2_2/mod2.py.
     python_breakpoint.PythonBreakpoint(
-        dict(self._template, location={'path': 'mod2.py', 'line': 3}),
-        self,
-        self,
-        None)
+        dict(self._template, location={
+            'path': 'mod2.py',
+            'line': 3
+        }), self, self, None)
 
     self.assertEqual(2, mod2.DoPrint())
 
     self.assertEqual(set(['BP_ID']), self._completed)
     self.assertLen(self._update_queue, 1)
     self.assertGreater(len(self._update_queue[0]['stackFrames']), 3)
-    self.assertEqual(
-        'DoPrint',
-        self._update_queue[0]['stackFrames'][0]['function'])
+    self.assertEqual('DoPrint',
+                     self._update_queue[0]['stackFrames'][0]['function'])
     self.assertTrue(self._update_queue[0]['isFinalState'])
     self.assertEqual(
-        'x',
-        self._update_queue[0]['stackFrames'][0]['locals'][0]['name'])
+        'x', self._update_queue[0]['stackFrames'][0]['locals'][0]['name'])
     self.assertEqual(
-        '2',
-        self._update_queue[0]['stackFrames'][0]['locals'][0]['value'])
+        '2', self._update_queue[0]['stackFrames'][0]['locals'][0]['value'])
 
     self.assertEmpty(imphook2._import_callbacks)
 
@@ -166,10 +163,10 @@ class PythonBreakpointTest(absltest.TestCase):
     # This breakpoint will be deferred. It can match any one of the modules
     # created above.
     python_breakpoint.PythonBreakpoint(
-        dict(self._template, location={'path': 'defer_print3.py', 'line': 3}),
-        self,
-        self,
-        None)
+        dict(self._template, location={
+            'path': 'defer_print3.py',
+            'line': 3
+        }), self, self, None)
 
     # Lazy import module. Activates breakpoint on the loaded module.
     import inner3_1.defer_print3  # pylint: disable=g-import-not-at-top
@@ -178,16 +175,13 @@ class PythonBreakpointTest(absltest.TestCase):
     self.assertEqual(set(['BP_ID']), self._completed)
     self.assertLen(self._update_queue, 1)
     self.assertGreater(len(self._update_queue[0]['stackFrames']), 3)
-    self.assertEqual(
-        'DoPrint',
-        self._update_queue[0]['stackFrames'][0]['function'])
+    self.assertEqual('DoPrint',
+                     self._update_queue[0]['stackFrames'][0]['function'])
     self.assertTrue(self._update_queue[0]['isFinalState'])
     self.assertEqual(
-        'x',
-        self._update_queue[0]['stackFrames'][0]['locals'][0]['name'])
+        'x', self._update_queue[0]['stackFrames'][0]['locals'][0]['name'])
     self.assertEqual(
-        '1',
-        self._update_queue[0]['stackFrames'][0]['locals'][0]['value'])
+        '1', self._update_queue[0]['stackFrames'][0]['locals'][0]['value'])
 
     self.assertEmpty(imphook2._import_callbacks)
 
@@ -195,10 +189,10 @@ class PythonBreakpointTest(absltest.TestCase):
     open(os.path.join(self._test_package_dir, 'never_print.py'), 'w').close()
 
     breakpoint = python_breakpoint.PythonBreakpoint(
-        dict(self._template, location={'path': 'never_print.py', 'line': 99}),
-        self,
-        self,
-        None)
+        dict(self._template, location={
+            'path': 'never_print.py',
+            'line': 99
+        }), self, self, None)
     breakpoint.Clear()
 
     self.assertFalse(self._completed)
@@ -208,10 +202,10 @@ class PythonBreakpointTest(absltest.TestCase):
     open(os.path.join(self._test_package_dir, 'defer_empty.py'), 'w').close()
 
     python_breakpoint.PythonBreakpoint(
-        dict(self._template, location={'path': 'defer_empty.py', 'line': 10}),
-        self,
-        self,
-        None)
+        dict(self._template, location={
+            'path': 'defer_empty.py',
+            'line': 10
+        }), self, self, None)
 
     self.assertFalse(self._completed)
     self.assertEmpty(self._update_queue)
@@ -235,10 +229,10 @@ class PythonBreakpointTest(absltest.TestCase):
     open(os.path.join(self._test_package_dir, 'defer_cancel.py'), 'w').close()
 
     breakpoint = python_breakpoint.PythonBreakpoint(
-        dict(self._template, location={'path': 'defer_cancel.py', 'line': 11}),
-        self,
-        self,
-        None)
+        dict(self._template, location={
+            'path': 'defer_cancel.py',
+            'line': 11
+        }), self, self, None)
     breakpoint.Clear()
 
     self.assertFalse(self._completed)
@@ -256,10 +250,10 @@ class PythonBreakpointTest(absltest.TestCase):
                                                    'NO_CODE_LINE_BELOW')
 
     python_breakpoint.PythonBreakpoint(
-        dict(self._template, location={'path': path, 'line': line}),
-        self,
-        self,
-        None)
+        dict(self._template, location={
+            'path': path,
+            'line': line
+        }), self, self, None)
     self.assertEqual(set(['BP_ID']), self._completed)
     self.assertLen(self._update_queue, 1)
     self.assertTrue(self._update_queue[0]['isFinalState'])
@@ -278,42 +272,46 @@ class PythonBreakpointTest(absltest.TestCase):
   def testBadExtension(self):
     for path in ['unknown.so', 'unknown', 'unknown.java', 'unknown.pyc']:
       python_breakpoint.PythonBreakpoint(
-          dict(self._template, location={'path': path, 'line': 83}),
-          self,
-          self,
-          None)
+          dict(self._template, location={
+              'path': path,
+              'line': 83
+          }), self, self, None)
       self.assertEqual(set(['BP_ID']), self._completed)
       self.assertLen(self._update_queue, 1)
       self.assertTrue(self._update_queue[0]['isFinalState'])
       self.assertEqual(
-          {'isError': True,
-           'refersTo': 'BREAKPOINT_SOURCE_LOCATION',
-           'description': {
-               'format': ('Only files with .py extension are supported')}},
-          self._update_queue[0]['status'])
+          {
+              'isError': True,
+              'refersTo': 'BREAKPOINT_SOURCE_LOCATION',
+              'description': {
+                  'format': ('Only files with .py extension are supported')
+              }
+          }, self._update_queue[0]['status'])
       self._update_queue = []
 
   def testRootInitFile(self):
-    for path in ['__init__.py', '/__init__.py', '////__init__.py',
-                 ' __init__.py ', ' //__init__.py']:
+    for path in [
+        '__init__.py', '/__init__.py', '////__init__.py', ' __init__.py ',
+        ' //__init__.py'
+    ]:
       python_breakpoint.PythonBreakpoint(
-          dict(self._template, location={'path': path, 'line': 83}),
-          self,
-          self,
-          None)
+          dict(self._template, location={
+              'path': path,
+              'line': 83
+          }), self, self, None)
       self.assertEqual(set(['BP_ID']), self._completed)
       self.assertLen(self._update_queue, 1)
       self.assertTrue(self._update_queue[0]['isFinalState'])
       self.assertEqual(
-          {'isError': True,
-           'refersTo': 'BREAKPOINT_SOURCE_LOCATION',
-           'description': {
-               'format':
-                   'Multiple modules matching $0. '
-                   'Please specify the module path.',
-               'parameters': ['__init__.py']
-           }},
-          self._update_queue[0]['status'])
+          {
+              'isError': True,
+              'refersTo': 'BREAKPOINT_SOURCE_LOCATION',
+              'description': {
+                  'format': 'Multiple modules matching $0. '
+                            'Please specify the module path.',
+                  'parameters': ['__init__.py']
+              }
+          }, self._update_queue[0]['status'])
       self._update_queue = []
 
   # Old module search algorithm rejects because there are too many matches.
@@ -333,10 +331,10 @@ class PythonBreakpointTest(absltest.TestCase):
 
     for path in ['/a/__init__.py', 'a/__init__.py', 'a/b/__init__.py']:
       python_breakpoint.PythonBreakpoint(
-          dict(self._template, location={'path': path, 'line': 2}),
-          self,
-          self,
-          None)
+          dict(self._template, location={
+              'path': path,
+              'line': 2
+          }), self, self, None)
 
       inner4.DoPrint()
 
@@ -344,9 +342,8 @@ class PythonBreakpointTest(absltest.TestCase):
       self.assertLen(self._update_queue, 1)
       self.assertTrue(self._update_queue[0]['isFinalState'])
       self.assertGreater(len(self._update_queue[0]['stackFrames']), 3)
-      self.assertEqual(
-          'DoPrint',
-          self._update_queue[0]['stackFrames'][0]['function'])
+      self.assertEqual('DoPrint',
+                       self._update_queue[0]['stackFrames'][0]['function'])
 
       self.assertEmpty(imphook2._import_callbacks)
       self._update_queue = []
@@ -364,11 +361,11 @@ class PythonBreakpointTest(absltest.TestCase):
     import pkg.pkg  # pylint: disable=g-import-not-at-top,unused-variable
 
     python_breakpoint.PythonBreakpoint(
-        dict(self._template,
-             location={'path': 'pkg/pkg/__init__.py', 'line': 2}),
-        self,
-        self,
-        None)
+        dict(
+            self._template, location={
+                'path': 'pkg/pkg/__init__.py',
+                'line': 2
+            }), self, self, None)
 
     pkg.pkg.DoPrint()
 
@@ -396,41 +393,42 @@ class PythonBreakpointTest(absltest.TestCase):
     import intern_err  # pylint: disable=g-import-not-at-top,unused-variable
 
     python_breakpoint.PythonBreakpoint(
-        dict(self._template, location={'path': 'intern_err.py', 'line': 100}),
-        self,
-        self,
-        None)
+        dict(self._template, location={
+            'path': 'intern_err.py',
+            'line': 100
+        }), self, self, None)
 
     self.assertEqual(set(['BP_ID']), self._completed)
     self.assertLen(self._update_queue, 1)
     self.assertEqual(
-        {'isError': True,
-         'description': {'format': 'Internal error occurred'}},
-        self._update_queue[0]['status'])
+        {
+            'isError': True,
+            'description': {
+                'format': 'Internal error occurred'
+            }
+        }, self._update_queue[0]['status'])
 
   def testInvalidCondition(self):
     python_breakpoint.PythonBreakpoint(
-        dict(self._template, condition='2+'),
-        self,
-        self,
-        None)
+        dict(self._template, condition='2+'), self, self, None)
     self.assertEqual(set(['BP_ID']), self._completed)
     self.assertLen(self._update_queue, 1)
     self.assertTrue(self._update_queue[0]['isFinalState'])
     self.assertEqual(
-        {'isError': True,
-         'refersTo': 'BREAKPOINT_CONDITION',
-         'description': {
-             'format': 'Expression could not be compiled: $0',
-             'parameters': ['unexpected EOF while parsing']}},
-        self._update_queue[0]['status'])
+        {
+            'isError': True,
+            'refersTo': 'BREAKPOINT_CONDITION',
+            'description': {
+                'format': 'Expression could not be compiled: $0',
+                'parameters': ['unexpected EOF while parsing']
+            }
+        }, self._update_queue[0]['status'])
 
   def testHit(self):
-    breakpoint = python_breakpoint.PythonBreakpoint(
-        self._template, self, self, None)
-    breakpoint._BreakpointEvent(
-        native.BREAKPOINT_EVENT_HIT,
-        inspect.currentframe())
+    breakpoint = python_breakpoint.PythonBreakpoint(self._template, self, self,
+                                                    None)
+    breakpoint._BreakpointEvent(native.BREAKPOINT_EVENT_HIT,
+                                inspect.currentframe())
     self.assertEqual(set(['BP_ID']), self._completed)
     self.assertLen(self._update_queue, 1)
     self.assertGreater(len(self._update_queue[0]['stackFrames']), 3)
@@ -441,68 +439,73 @@ class PythonBreakpointTest(absltest.TestCase):
     self._template['createTime'] = python_test_util.DateTimeToTimestampNew(
         self._base_time)
 
-    breakpoint = python_breakpoint.PythonBreakpoint(
-        self._template, self, self, None)
-    breakpoint._BreakpointEvent(
-        native.BREAKPOINT_EVENT_HIT,
-        inspect.currentframe())
+    breakpoint = python_breakpoint.PythonBreakpoint(self._template, self, self,
+                                                    None)
+    breakpoint._BreakpointEvent(native.BREAKPOINT_EVENT_HIT,
+                                inspect.currentframe())
     self.assertEqual(set(['BP_ID']), self._completed)
     self.assertLen(self._update_queue, 1)
     self.assertGreater(len(self._update_queue[0]['stackFrames']), 3)
     self.assertTrue(self._update_queue[0]['isFinalState'])
 
   def testDoubleHit(self):
-    breakpoint = python_breakpoint.PythonBreakpoint(
-        self._template, self, self, None)
-    breakpoint._BreakpointEvent(
-        native.BREAKPOINT_EVENT_HIT,
-        inspect.currentframe())
-    breakpoint._BreakpointEvent(
-        native.BREAKPOINT_EVENT_HIT,
-        inspect.currentframe())
+    breakpoint = python_breakpoint.PythonBreakpoint(self._template, self, self,
+                                                    None)
+    breakpoint._BreakpointEvent(native.BREAKPOINT_EVENT_HIT,
+                                inspect.currentframe())
+    breakpoint._BreakpointEvent(native.BREAKPOINT_EVENT_HIT,
+                                inspect.currentframe())
     self.assertEqual(set(['BP_ID']), self._completed)
     self.assertLen(self._update_queue, 1)
 
   def testEndToEndUnconditional(self):
+
     def Trigger():
       pass  # BPTAG: E2E_UNCONDITIONAL
 
     path, line = python_test_util.ResolveTag(type(self), 'E2E_UNCONDITIONAL')
     breakpoint = python_breakpoint.PythonBreakpoint(
-        {'id': 'BP_ID',
-         'location': {'path': path, 'line': line}},
-        self,
-        self,
-        None)
+        {
+            'id': 'BP_ID',
+            'location': {
+                'path': path,
+                'line': line
+            }
+        }, self, self, None)
     self.assertEmpty(self._update_queue)
     Trigger()
     self.assertLen(self._update_queue, 1)
     breakpoint.Clear()
 
   def testEndToEndConditional(self):
+
     def Trigger():
       for i in range(2):
         self.assertLen(self._update_queue, i)  # BPTAG: E2E_CONDITIONAL
 
     path, line = python_test_util.ResolveTag(type(self), 'E2E_CONDITIONAL')
     breakpoint = python_breakpoint.PythonBreakpoint(
-        {'id': 'BP_ID',
-         'location': {'path': path, 'line': line},
-         'condition': 'i == 1'},
-        self,
-        self,
-        None)
+        {
+            'id': 'BP_ID',
+            'location': {
+                'path': path,
+                'line': line
+            },
+            'condition': 'i == 1'
+        }, self, self, None)
     Trigger()
     breakpoint.Clear()
 
   def testEndToEndCleared(self):
     path, line = python_test_util.ResolveTag(type(self), 'E2E_CLEARED')
     breakpoint = python_breakpoint.PythonBreakpoint(
-        {'id': 'BP_ID',
-         'location': {'path': path, 'line': line}},
-        self,
-        self,
-        None)
+        {
+            'id': 'BP_ID',
+            'location': {
+                'path': path,
+                'line': line
+            }
+        }, self, self, None)
     breakpoint.Clear()
     self.assertEmpty(self._update_queue)  # BPTAG: E2E_CLEARED
 
@@ -510,13 +513,11 @@ class PythonBreakpointTest(absltest.TestCase):
     events = [
         native.BREAKPOINT_EVENT_GLOBAL_CONDITION_QUOTA_EXCEEDED,
         native.BREAKPOINT_EVENT_BREAKPOINT_CONDITION_QUOTA_EXCEEDED,
-        native.BREAKPOINT_EVENT_CONDITION_EXPRESSION_MUTABLE]
+        native.BREAKPOINT_EVENT_CONDITION_EXPRESSION_MUTABLE
+    ]
     for event in events:
-      breakpoint = python_breakpoint.PythonBreakpoint(
-          self._template,
-          self,
-          self,
-          None)
+      breakpoint = python_breakpoint.PythonBreakpoint(self._template, self,
+                                                      self, None)
       breakpoint._BreakpointEvent(event, None)
       self.assertLen(self._update_queue, 1)
       self.assertEqual(set(['BP_ID']), self._completed)
@@ -525,12 +526,11 @@ class PythonBreakpointTest(absltest.TestCase):
       self._completed = set()
 
   def testExpirationTime(self):
-    breakpoint = python_breakpoint.PythonBreakpoint(
-        self._template, self, self, None)
+    breakpoint = python_breakpoint.PythonBreakpoint(self._template, self, self,
+                                                    None)
     breakpoint.Clear()
     self.assertEqual(
-        datetime(year=2015, month=1, day=2),
-        breakpoint.GetExpirationTime())
+        datetime(year=2015, month=1, day=2), breakpoint.GetExpirationTime())
 
   def testExpirationTimeWithExpiresIn(self):
     definition = self._template.copy()
@@ -538,40 +538,45 @@ class PythonBreakpointTest(absltest.TestCase):
         'seconds': 300  # 5 minutes
     }
 
-    breakpoint = python_breakpoint.PythonBreakpoint(
-        definition, self, self, None)
+    breakpoint = python_breakpoint.PythonBreakpoint(definition, self, self,
+                                                    None)
     breakpoint.Clear()
     self.assertEqual(
-        datetime(year=2015, month=1, day=2),
-        breakpoint.GetExpirationTime())
+        datetime(year=2015, month=1, day=2), breakpoint.GetExpirationTime())
 
   def testExpiration(self):
-    breakpoint = python_breakpoint.PythonBreakpoint(
-        self._template, self, self, None)
+    breakpoint = python_breakpoint.PythonBreakpoint(self._template, self, self,
+                                                    None)
     breakpoint.ExpireBreakpoint()
     self.assertEqual(set(['BP_ID']), self._completed)
     self.assertLen(self._update_queue, 1)
     self.assertTrue(self._update_queue[0]['isFinalState'])
     self.assertEqual(
-        {'isError': True,
-         'refersTo': 'BREAKPOINT_AGE',
-         'description': {'format': 'The snapshot has expired'}},
-        self._update_queue[0]['status'])
+        {
+            'isError': True,
+            'refersTo': 'BREAKPOINT_AGE',
+            'description': {
+                'format': 'The snapshot has expired'
+            }
+        }, self._update_queue[0]['status'])
 
   def testLogpointExpiration(self):
     definition = self._template.copy()
     definition['action'] = 'LOG'
-    breakpoint = python_breakpoint.PythonBreakpoint(
-        definition, self, self, None)
+    breakpoint = python_breakpoint.PythonBreakpoint(definition, self, self,
+                                                    None)
     breakpoint.ExpireBreakpoint()
     self.assertEqual(set(['BP_ID']), self._completed)
     self.assertLen(self._update_queue, 1)
     self.assertTrue(self._update_queue[0]['isFinalState'])
     self.assertEqual(
-        {'isError': True,
-         'refersTo': 'BREAKPOINT_AGE',
-         'description': {'format': 'The logpoint has expired'}},
-        self._update_queue[0]['status'])
+        {
+            'isError': True,
+            'refersTo': 'BREAKPOINT_AGE',
+            'description': {
+                'format': 'The logpoint has expired'
+            }
+        }, self._update_queue[0]['status'])
 
   def testNormalizePath(self):
     # Removes leading '/' character.
@@ -587,8 +592,10 @@ class PythonBreakpointTest(absltest.TestCase):
       self.assertEqual('__init__.py', python_breakpoint._NormalizePath(path))
 
     # Normalizes the relative path.
-    for path in ['  ./__init__.py', '././__init__.py', ' .//abc/../__init__.py',
-                 '  ///abc///..///def/..////__init__.py']:
+    for path in [
+        '  ./__init__.py', '././__init__.py', ' .//abc/../__init__.py',
+        '  ///abc///..///def/..////__init__.py'
+    ]:
       self.assertEqual('__init__.py', python_breakpoint._NormalizePath(path))
 
     # Does not remove non-leading, non-trailing space, or non-leading '/'
@@ -602,6 +609,7 @@ class PythonBreakpointTest(absltest.TestCase):
     self.assertEqual(
         'foo/bar/baz/__in it__.py',
         python_breakpoint._NormalizePath('/foo/bar/baz/__in it__.py'))
+
 
 if __name__ == '__main__':
   absltest.main()

--- a/tests/python_test_util.py
+++ b/tests/python_test_util.py
@@ -129,8 +129,8 @@ def PackFrameVariable(breakpoint, name, frame=0, collection='locals'):
     if variable['name'] == name:
       return _Pack(variable, breakpoint)
 
-  raise AssertionError('Variable %s not found in frame %d collection %s' % (
-      name, frame, collection))
+  raise AssertionError('Variable %s not found in frame %d collection %s' %
+                       (name, frame, collection))
 
 
 def PackWatchedExpression(breakpoint, expression):
@@ -183,4 +183,3 @@ def _Pack(variable, breakpoint):
         key=lambda m: m.get('name', ''))
 
   return packed
-

--- a/tests/uniquifier_computer_test.py
+++ b/tests/uniquifier_computer_test.py
@@ -51,75 +51,71 @@ class UniquifierComputerTest(absltest.TestCase):
       del sys.path[0]
 
   def testEmpty(self):
-    self.assertListEqual(
-        [],
-        self._Compute({}))
+    self.assertListEqual([], self._Compute({}))
 
   def testBundle(self):
-    self.assertListEqual(
-        ['first.py:1',
-         'in1/__init__.py:6',
-         'in1/a.py:3',
-         'in1/b.py:4',
-         'in1/in2/__init__.py:7',
-         'in1/in2/c.py:5',
-         'second.py:2'],
-        self._Compute({
-            'db.app': 'abc',
-            'first.py': 'a',
-            'second.py': 'bb',
-            'in1/a.py': 'ccc',
-            'in1/b.py': 'dddd',
-            'in1/in2/c.py': 'eeeee',
-            'in1/__init__.py': 'ffffff',
-            'in1/in2/__init__.py': 'ggggggg'}))
+    self.assertListEqual([
+        'first.py:1', 'in1/__init__.py:6', 'in1/a.py:3', 'in1/b.py:4',
+        'in1/in2/__init__.py:7', 'in1/in2/c.py:5', 'second.py:2'
+    ],
+                         self._Compute({
+                             'db.app': 'abc',
+                             'first.py': 'a',
+                             'second.py': 'bb',
+                             'in1/a.py': 'ccc',
+                             'in1/b.py': 'dddd',
+                             'in1/in2/c.py': 'eeeee',
+                             'in1/__init__.py': 'ffffff',
+                             'in1/in2/__init__.py': 'ggggggg'
+                         }))
 
   def testEmptyFile(self):
-    self.assertListEqual(
-        ['empty.py:0'],
-        self._Compute({
-            'empty.py': ''}))
+    self.assertListEqual(['empty.py:0'], self._Compute({'empty.py': ''}))
 
   def testNonPythonFilesIgnored(self):
-    self.assertListEqual(
-        ['real.py:1'],
-        self._Compute({
-            'file.p': '',
-            'file.pya': '',
-            'real.py': '1'}))
+    self.assertListEqual(['real.py:1'],
+                         self._Compute({
+                             'file.p': '',
+                             'file.pya': '',
+                             'real.py': '1'
+                         }))
 
   def testNonPackageDirectoriesIgnored(self):
-    self.assertListEqual(
-        ['dir2/__init__.py:1'],
-        self._Compute({
-            'dir1/file.py': '',
-            'dir2/__init__.py': 'a',
-            'dir2/image.gif': ''}))
+    self.assertListEqual(['dir2/__init__.py:1'],
+                         self._Compute({
+                             'dir1/file.py': '',
+                             'dir2/__init__.py': 'a',
+                             'dir2/image.gif': ''
+                         }))
 
   def testDepthLimit(self):
-    self.assertListEqual(
-        [''.join(str(n) + '/' for n in range(1, m + 1)) + '__init__.py:%d' % m
-         for m in range(9, 0, -1)],
-        self._Compute({
-            '1/__init__.py': '1',
-            '1/2/__init__.py': '2' * 2,
-            '1/2/3/__init__.py': '3' * 3,
-            '1/2/3/4/__init__.py': '4' * 4,
-            '1/2/3/4/5/__init__.py': '5' * 5,
-            '1/2/3/4/5/6/__init__.py': '6' * 6,
-            '1/2/3/4/5/6/7/__init__.py': '7' * 7,
-            '1/2/3/4/5/6/7/8/__init__.py': '8' * 8,
-            '1/2/3/4/5/6/7/8/9/__init__.py': '9' * 9,
-            '1/2/3/4/5/6/7/8/9/10/__init__.py': 'a' * 10,
-            '1/2/3/4/5/6/7/8/9/10/11/__init__.py': 'b' * 11}))
+    self.assertListEqual([
+        ''.join(str(n) + '/'
+                for n in range(1, m + 1)) + '__init__.py:%d' % m
+        for m in range(9, 0, -1)
+    ],
+                         self._Compute({
+                             '1/__init__.py': '1',
+                             '1/2/__init__.py': '2' * 2,
+                             '1/2/3/__init__.py': '3' * 3,
+                             '1/2/3/4/__init__.py': '4' * 4,
+                             '1/2/3/4/5/__init__.py': '5' * 5,
+                             '1/2/3/4/5/6/__init__.py': '6' * 6,
+                             '1/2/3/4/5/6/7/__init__.py': '7' * 7,
+                             '1/2/3/4/5/6/7/8/__init__.py': '8' * 8,
+                             '1/2/3/4/5/6/7/8/9/__init__.py': '9' * 9,
+                             '1/2/3/4/5/6/7/8/9/10/__init__.py': 'a' * 10,
+                             '1/2/3/4/5/6/7/8/9/10/11/__init__.py': 'b' * 11
+                         }))
 
   def testPrecedence(self):
-    self.assertListEqual(
-        ['my.py:3'],
-        self._Compute({
-            'my.pyo': 'a',
-            'my.pyc': 'aa',
-            'my.py': 'aaa'}))
+    self.assertListEqual(['my.py:3'],
+                         self._Compute({
+                             'my.pyo': 'a',
+                             'my.pyc': 'aa',
+                             'my.py': 'aaa'
+                         }))
+
 
 if __name__ == '__main__':
   absltest.main()

--- a/tests/yaml_data_visibility_config_reader_test.py
+++ b/tests/yaml_data_visibility_config_reader_test.py
@@ -35,18 +35,21 @@ class YamlDataVisibilityConfigReaderTest(absltest.TestCase):
         - bl1
     """
     path_prefix = 'googleclouddebugger.'
-    with mock.patch(path_prefix + 'yaml_data_visibility_config_reader.open',
-                    create=True) as m:
+    with mock.patch(
+        path_prefix + 'yaml_data_visibility_config_reader.open',
+        create=True) as m:
       m.return_value = StringIOOpen(data)
       config = yaml_data_visibility_config_reader.OpenAndRead()
-      m.assert_called_with(os.path.join(sys.path[0], 'debugger-blacklist.yaml'),
-                           'r')
+      m.assert_called_with(
+          os.path.join(sys.path[0], 'debugger-blacklist.yaml'), 'r')
       self.assertEqual(config.blacklist_patterns, ['bl1'])
 
   def testOpenAndReadFileNotFound(self):
     path_prefix = 'googleclouddebugger.'
-    with mock.patch(path_prefix + 'yaml_data_visibility_config_reader.open',
-                    create=True, side_effect=IOError('IO Error')):
+    with mock.patch(
+        path_prefix + 'yaml_data_visibility_config_reader.open',
+        create=True,
+        side_effect=IOError('IO Error')):
       f = yaml_data_visibility_config_reader.OpenAndRead()
       self.assertIsNone(f)
 
@@ -65,6 +68,7 @@ class YamlDataVisibilityConfigReaderTest(absltest.TestCase):
     self.assertItemsEqual(config.whitelist_patterns, ('wl1', 'wl2.*'))
 
   def testYAMLLoadError(self):
+
     class ErrorIO(object):
 
       def read(self, size):


### PR DESCRIPTION
I applied the formatter and cleaned a couple linter errors in __init__.py but there's a lot of linting yet to do.

The linter errors can be easier addressed after python2 compatibility is removed, so will be deferred for now.