### PR TITLE
chore: add .coverage to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /src/setup.cfg
 __pycache__/
 *.egg-info/
+.coverage


### PR DESCRIPTION
It doesn't make sense to check in code coverage reports.