### PR TITLE
fix: safely handle multiple deletions of a breakpoint

### DIFF
--- a/src/googleclouddebugger/firebase_client.py
+++ b/src/googleclouddebugger/firebase_client.py
@@ -373,7 +373,8 @@ class FirebaseClient(object):
         # If deleting, event.path will be /{breakpointid}
         if event.path != '/':
           breakpoint_id = event.path[1:]
-          del self._breakpoints[breakpoint_id]
+          # Breakpoint may have already been deleted, so pop for possible no-op.
+          self._breakpoints.pop(breakpoint_id, None) 
       else:
         if event.path == '/':
           # New set of breakpoints.


### PR DESCRIPTION
In some situations, multiple attempts to delete a breakpoint can occur.  For example, if a breakpoint becomes final on two machines simultaneously, an agent may delete a breakpoint locally and subsequently receive an update that the other machine deleted it.