### PR TITLE
chore: bump firebase-admin version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ google-auth>=1.0.0
 google-auth-httplib2
 google-api-python-client
 google-api-core
-firebase_admin==5.2.0
+firebase_admin>=5.3.0
 pyyaml

--- a/src/setup.py
+++ b/src/setup.py
@@ -105,7 +105,7 @@ setup(
         'google-auth>=1.0.0',
         'google-auth-httplib2',
         'google-api-core',
-        'firebase-admin==5.2.0',
+        'firebase-admin>=5.3.0',
         'pyyaml',
     ],
     packages=['googleclouddebugger'],


### PR DESCRIPTION
5.4.0 deprecated support for Python 3.6 and 6.0.0 removed it, while this library still maintains support for 3.6.

For now, I'm changing the restriction to firebase_admin>=5.3.0 which should address the concerns.

Fixes #59 