### PR TITLE
fix: Breakpoint Expiry in Firebase Backend Version

### DIFF
--- a/src/googleclouddebugger/firebase_client.py
+++ b/src/googleclouddebugger/firebase_client.py
@@ -311,6 +311,12 @@ class FirebaseClient(object):
 
     self._StartMarkActiveTimer()
 
+    while not self._shutdown:
+      if self.on_idle is not None:
+        self.on_idle()
+
+    time.sleep(1)
+
   def _TransmissionThreadProc(self):
     """Entry point for the transmission worker thread."""
 

--- a/src/googleclouddebugger/firebase_client.py
+++ b/src/googleclouddebugger/firebase_client.py
@@ -315,7 +315,7 @@ class FirebaseClient(object):
       if self.on_idle is not None:
         self.on_idle()
 
-    time.sleep(1)
+      time.sleep(1)
 
   def _TransmissionThreadProc(self):
     """Entry point for the transmission worker thread."""

--- a/src/googleclouddebugger/python_breakpoint.py
+++ b/src/googleclouddebugger/python_breakpoint.py
@@ -252,10 +252,18 @@ class PythonBreakpoint(object):
     return self.definition['id']
 
   def GetExpirationTime(self):
-    """Computes the timestamp at which this breakpoint will expire."""
+    """Computes the timestamp at which this breakpoint will expire.
+
+    If no creation time can be found an expiration time in the past will be
+    used.
+    """
     return self.GetCreateTime() + self.expiration_period
 
   def GetCreateTime(self):
+    """Retrieves the creation time of this breakpoint.
+
+    If no creation time can be found a creation time in the past will be used.
+    """
     if 'createTime' in self.definition:
       return self.GetTimeFromRfc3339Str(self.definition['createTime'])
     else:

--- a/src/googleclouddebugger/python_breakpoint.py
+++ b/src/googleclouddebugger/python_breakpoint.py
@@ -253,15 +253,32 @@ class PythonBreakpoint(object):
 
   def GetExpirationTime(self):
     """Computes the timestamp at which this breakpoint will expire."""
-    # TODO: Move this to a common method.
-    if '.' not in self.definition['createTime']:
+    return self.GetCreateTime() + self.expiration_period
+
+  def GetCreateTime(self):
+    if 'createTime' in self.definition:
+      return self.GetTimeFromRfc3339Str(self.definition['createTime'])
+    else:
+      return self.GetTimeFromUnixMsec(
+          self.definition.get('createTimeUnixMsec', 0))
+
+  def GetTimeFromRfc3339Str(self, rfc3339_str):
+    #TODO : Move this to a common method.
+    if '.' not in rfc3339_str:
       fmt = '%Y-%m-%dT%H:%M:%S%Z'
     else:
       fmt = '%Y-%m-%dT%H:%M:%S.%f%Z'
 
-    create_datetime = datetime.strptime(
-        self.definition['createTime'].replace('Z', 'UTC'), fmt)
-    return create_datetime + self.expiration_period
+    return datetime.strptime(rfc3339_str.replace('Z', 'UTC'), fmt)
+
+  def GetTimeFromUnixMsec(self, unix_msec):
+    try:
+      return datetime.fromtimestamp(unix_msec / 1000)
+    except (TypeError, ValueError, OSError, OverflowError) as e:
+      native.LogWarning(
+        'Unexpected error (%s) occured processing unix_msec %s, breakpoint: %s'
+        % (repr(e), str(unix_msec), self.GetBreakpointId()))
+      return datetime.fromtimestamp(0)
 
   def ExpireBreakpoint(self):
     """Expires this breakpoint."""

--- a/src/googleclouddebugger/python_breakpoint.py
+++ b/src/googleclouddebugger/python_breakpoint.py
@@ -263,7 +263,6 @@ class PythonBreakpoint(object):
           self.definition.get('createTimeUnixMsec', 0))
 
   def GetTimeFromRfc3339Str(self, rfc3339_str):
-    #TODO : Move this to a common method.
     if '.' not in rfc3339_str:
       fmt = '%Y-%m-%dT%H:%M:%S%Z'
     else:

--- a/tests/py/python_breakpoint_test.py
+++ b/tests/py/python_breakpoint_test.py
@@ -457,6 +457,22 @@ class PythonBreakpointTest(absltest.TestCase):
     self.assertGreater(len(self._update_queue[0]['stackFrames']), 3)
     self.assertTrue(self._update_queue[0]['isFinalState'])
 
+  def testHitTimestampUnixMsec(self):
+    # Using the Snapshot Debugger (Firebase backend) version of creation time
+    self._template.pop('createTime', None);
+    self._template[
+      'createTimeUnixMsec'] = python_test_util.DateTimeToUnixMsec(
+        self._base_time)
+
+    breakpoint = python_breakpoint.PythonBreakpoint(self._template, self, self,
+                                                    None)
+    breakpoint._BreakpointEvent(native.BREAKPOINT_EVENT_HIT,
+                                inspect.currentframe())
+    self.assertEqual(set(['BP_ID']), self._completed)
+    self.assertLen(self._update_queue, 1)
+    self.assertGreater(len(self._update_queue[0]['stackFrames']), 3)
+    self.assertTrue(self._update_queue[0]['isFinalState'])
+
   def testDoubleHit(self):
     breakpoint = python_breakpoint.PythonBreakpoint(self._template, self, self,
                                                     None)
@@ -540,6 +556,18 @@ class PythonBreakpointTest(absltest.TestCase):
     breakpoint.Clear()
     self.assertEqual(
         datetime(year=2015, month=1, day=2), breakpoint.GetExpirationTime())
+
+  def testExpirationTimeUnixMsec(self):
+    # Using the Snapshot Debugger (Firebase backend) version of creation time
+    self._template.pop('createTime', None);
+    self._template[
+      'createTimeUnixMsec'] = python_test_util.DateTimeToUnixMsec(
+        self._base_time)
+    breakpoint = python_breakpoint.PythonBreakpoint(self._template, self, self,
+                                                    None)
+    breakpoint.Clear()
+    self.assertEqual(
+        self._base_time + timedelta(hours=24), breakpoint.GetExpirationTime())
 
   def testExpirationTimeWithExpiresIn(self):
     definition = self._template.copy()

--- a/tests/py/python_test_util.py
+++ b/tests/py/python_test_util.py
@@ -106,6 +106,10 @@ def DateTimeToTimestampNew(t):
   """
   return t.strftime('%Y-%m-%dT%H:%M:%S') + 'Z'
 
+def DateTimeToUnixMsec(t):
+  """Returns the Unix time as in integer value in milliseconds"""
+  return int(t.timestamp() * 1000)
+
 
 def PackFrameVariable(breakpoint, name, frame=0, collection='locals'):
   """Finds local variable or argument by name.


### PR DESCRIPTION
- The firebase backend client code now calls on_idle periodically
- The breakpoint expiration code now checks for the `createTimeUnixMsec` breakpoint field

Fixes #72 