### PR TITLE
chore: Add extra test cleanup to build scripts

### DIFF
--- a/build_and_test.sh
+++ b/build_and_test.sh
@@ -1,5 +1,8 @@
 #!/bin/bash -e
 
+# Clean up any previous generated test files.
+rm -rf tests/py/__pycache__
+
 cd src
 ./build.sh
 cd ..
@@ -10,3 +13,6 @@ pip3 install -r requirements_dev.txt
 pip3 install src/dist/* --force-reinstall
 python3 -m pytest tests/py
 deactivate
+
+# Clean up any generated test files.
+rm -rf tests/py/__pycache__

--- a/src/build-wheels.sh
+++ b/src/build-wheels.sh
@@ -10,8 +10,14 @@ ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") >/dev/null; /bin/pwd -P)
 # Parallelize the build over N threads where N is the number of cores * 1.5.
 PARALLEL_BUILD_OPTION="-j $(($(nproc 2> /dev/null || echo 4)*3/2))"
 
-# Clean up any previous build files.
-rm -rf ${ROOT}/build ${ROOT}/dist ${ROOT}/setup.cfg
+# Clean up any previous build/test files.
+rm -rf \
+  ${ROOT}/build \
+  ${ROOT}/dist \
+  ${ROOT}/setup.cfg \
+  ${ROOT}/google_python_cloud_debugger.egg-info \
+  /io/dist \
+  /io/tests/py/__pycache__
 
 # Create directory for third-party libraries.
 mkdir -p ${ROOT}/build/third_party
@@ -78,6 +84,11 @@ done
 popd
 
 # Clean up temporary directories.
-rm -rf ${ROOT}/build ${ROOT}/setup.cfg
+rm -rf \
+  ${ROOT}/build \
+  ${ROOT}/setup.cfg \
+  ${ROOT}/google_python_cloud_debugger.egg-info \
+  /io/tests/py/__pycache__
+
 echo "Build artifacts are in the dist directory"
 

--- a/src/build.sh
+++ b/src/build.sh
@@ -42,7 +42,11 @@ ROOT=$(cd $(dirname "${BASH_SOURCE[0]}") >/dev/null; /bin/pwd -P)
 PARALLEL_BUILD_OPTION="-j $(($(nproc 2> /dev/null || echo 4)*3/2))"
 
 # Clean up any previous build files.
-rm -rf ${ROOT}/build ${ROOT}/dist ${ROOT}/setup.cfg
+rm -rf \
+  ${ROOT}/build \
+  ${ROOT}/dist \
+  ${ROOT}/setup.cfg \
+  ${ROOT}/google_python_cloud_debugger.egg-info
 
 # Create directory for third-party libraries.
 mkdir -p ${ROOT}/build/third_party
@@ -91,3 +95,8 @@ pushd ${ROOT}
 "${PYTHON:-python3}" -m pip wheel . --no-deps -w dist
 popd
 
+# Clean up temporary directories.
+rm -rf \
+  ${ROOT}/build \
+  ${ROOT}/setup.cfg \
+  ${ROOT}/google_python_cloud_debugger.egg-info


### PR DESCRIPTION
This addresses an issue where first running `./build_and_test.sh` followed by `build_dist.sh` could see some test failures while running the seconde script. One concrete scenario was when the local python version was 3.10.9 while version 3.10.10 was used during `build_dist.sh`.