### PR TITLE
fix: address some cases where jumps were not being updated

### DIFF
--- a/src/googleclouddebugger/bytecode_manipulator.cc
+++ b/src/googleclouddebugger/bytecode_manipulator.cc
@@ -154,7 +154,6 @@ static int GetBranchTarget(int offset, PythonInstruction instruction) {
 #endif
 
     case BRANCH_ABSOLUTE_OPCODE:
-      LOG(INFO) << "branch absolute";
 #if PY_VERSION_HEX < 0x030A0000
       return instruction.argument;
 #else

--- a/src/googleclouddebugger/bytecode_manipulator.cc
+++ b/src/googleclouddebugger/bytecode_manipulator.cc
@@ -133,6 +133,9 @@ static PythonOpcodeType GetOpcodeType(uint8_t opcode) {
     // Removed in Python 3.8.
     case CONTINUE_LOOP:
 #endif
+#if PY_VERSION_HEX >= 0x03090000
+    case JUMP_IF_NOT_EXC_MATCH:
+#endif
       return BRANCH_ABSOLUTE_OPCODE;
 
     default:
@@ -144,10 +147,19 @@ static PythonOpcodeType GetOpcodeType(uint8_t opcode) {
 static int GetBranchTarget(int offset, PythonInstruction instruction) {
   switch (GetOpcodeType(instruction.opcode)) {
     case BRANCH_DELTA_OPCODE:
+#if PY_VERSION_HEX < 0x030A0000
       return offset + instruction.size + instruction.argument;
+#else
+      return offset + instruction.size + instruction.argument * 2;
+#endif
 
     case BRANCH_ABSOLUTE_OPCODE:
+      LOG(INFO) << "branch absolute";
+#if PY_VERSION_HEX < 0x030A0000
       return instruction.argument;
+#else
+      return instruction.argument * 2;
+#endif
 
     default:
       DCHECK(false) << "Not a branch instruction";
@@ -428,13 +440,21 @@ static bool InsertAndUpdateBranchInstructions(
         // argument of 0 even when it is not required. This needs to be taken
         // into account when calculating the target of a branch instruction.
         int inst_size = std::max(instruction.size, it->original_size);
+#if PY_VERSION_HEX < 0x030A0000
         int32_t target = it->current_offset + inst_size + arg;
+#else
+        int32_t target = it->current_offset + inst_size + arg * 2;
+#endif
         need_to_update = it->current_offset < insertion.current_offset &&
                          insertion.current_offset < target;
       } else if (opcode_type == BRANCH_ABSOLUTE_OPCODE) {
         // For absolute branches, the argument needs to be updated if the
         // insertion before the target.
+#if PY_VERSION_HEX < 0x030A0000
         need_to_update = insertion.current_offset < arg;
+#else
+        need_to_update = insertion.current_offset < arg * 2;
+#endif
       }
 
       // If we are inserting the original method call instructions, we want to


### PR DESCRIPTION
In Python 3.10, due to the fact that jump instruction arguments have changed from byte offsets to instruction offsets, in some cases the jumps will not be updated because it is not noticed that their jump targets are being moved.

Consider the following example:
```
 39          12 LOAD_FAST                0 (index)
             14 LOAD_CONST               0 (None)
             16 IS_OP                    0
             18 POP_JUMP_IF_FALSE       12 (to 24)

 40          20 LOAD_CONST               1 ('Foo\n')
             22 RETURN_VALUE

 41     >>   24 SETUP_FINALLY           18 (to 62)
```
Adding a breakpoint on line 40 will insert the breakpoint code between the ```POP_JUMP_IF_FALSE``` and its target:

```
 39          12 LOAD_FAST                0 (index)
             14 LOAD_CONST               0 (None)
             16 IS_OP                    0
             18 POP_JUMP_IF_FALSE       12 (to 24)

 40          20 LOAD_CONST               7 (<built-in method Callback of cdbg_native._Callback object at 0x7f6236913fd0>)
             22 CALL_FUNCTION            0
        >>   24 POP_TOP
             26 LOAD_CONST               1 ('Foo\n')
             28 RETURN_VALUE

 41          30 SETUP_FINALLY           21 (to 74)
```

Note that the ```POP_JUMP_IF_FALSE``` target is not updated, and is pointing to the wrong instruction.  This is because the argument is 12, which is incorrectly interpretted as the memory offset and thus is jumping to a code location that has not been moved.

The correct bytecode to generate is as follows:
```
 39          12 LOAD_FAST                0 (index)
             14 LOAD_CONST               0 (None)
             16 IS_OP                    0
             18 POP_JUMP_IF_FALSE       15 (to 30)

 40          20 LOAD_CONST               7 (<built-in method Callback of cdbg_native._Callback object at 0x7f6236913fd0>)
             22 CALL_FUNCTION            0
             24 POP_TOP
             26 LOAD_CONST               1 ('Foo\n')
             28 RETURN_VALUE

 41     >>   30 SETUP_FINALLY           21 (to 74)
```